### PR TITLE
feat(ci): add matrix dashboard and PR diff comment (#21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,20 +241,19 @@ jobs:
             -L "${BASELINE_URL}" \
             -o .github-actionspec-dashboard/baseline/baseline.zip
           unzip -q .github-actionspec-dashboard/baseline/baseline.zip -d .github-actionspec-dashboard/baseline
-      - name: Generate matrix dashboard
-        run: |
-          if [[ -f .github-actionspec-dashboard/baseline/validation-report.json ]]; then
-            just dashboard-report \
-              .github-actionspec-dashboard/current/validation-report.json \
-              .github-actionspec-dashboard/dashboard.md \
-              .github-actionspec-dashboard/baseline/validation-report.json
-          else
-            just dashboard-report \
-              .github-actionspec-dashboard/current/validation-report.json \
-              .github-actionspec-dashboard/dashboard.md
-          fi
-      - name: Add matrix dashboard to summary
-        run: cat .github-actionspec-dashboard/dashboard.md >> "${GITHUB_STEP_SUMMARY}"
+      - name: Generate matrix dashboard through the action
+        id: matrix-dashboard
+        continue-on-error: true
+        uses: ./
+        with:
+          repo: .
+          workflow: ci.yml
+          actual: tests/fixtures/ci
+          report-file: .github-actionspec-dashboard/current/validation-report.json
+          baseline-report: .github-actionspec-dashboard/baseline/validation-report.json
+          dashboard-file: .github-actionspec-dashboard/current/dashboard.md
+          comment-pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+          github-token: ${{ github.token }}
       - name: Upload matrix dashboard artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -262,53 +261,7 @@ jobs:
           name: ci-matrix-dashboard
           path: |
             .github-actionspec-dashboard/current/validation-report.json
-            .github-actionspec-dashboard/dashboard.md
-      - name: Comment matrix on PR
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: actions/github-script@v8
-        env:
-          MATRIX_BASELINE_SOURCE: ${{ steps.baseline-matrix.outputs.baseline_source }}
-        with:
-          script: |
-            const fs = require("fs");
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const issue_number = context.issue.number;
-            const marker = "<!-- github-actionspec-matrix -->";
-            const dashboard = fs.readFileSync(".github-actionspec-dashboard/dashboard.md", "utf8");
-            const baselineSource = process.env.MATRIX_BASELINE_SOURCE;
-            const body = [
-              marker,
-              "## Workflow Matrix Dashboard",
-              baselineSource ? `Baseline: \`${baselineSource}\`` : "Baseline: `none`",
-              "",
-              dashboard,
-            ].join("\n");
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-
-            const existing = comments.find((comment) => comment.body?.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body,
-              });
-            }
+            .github-actionspec-dashboard/current/dashboard.md
       - name: Generate coverage
         run: just coverage-ci
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -166,6 +167,148 @@ jobs:
             echo "::error::The skipped build fixture should fail validation."
             exit 1
           fi
+      - name: Prepare matrix dashboard workspace
+        run: mkdir -p .github-actionspec-dashboard/current .github-actionspec-dashboard/baseline
+      - name: Generate current validation report
+        id: current-matrix
+        continue-on-error: true
+        run: just validate-repo-report . ci.yml tests/fixtures/ci .github-actionspec-dashboard/current/validation-report.json
+      - name: Find baseline matrix artifact
+        id: baseline-matrix
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const workflowId = "ci.yml";
+            const artifactName = "ci-matrix-dashboard";
+
+            async function findArtifactUrl(branch, eventName) {
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner,
+                repo,
+                workflow_id: workflowId,
+                branch,
+                event: eventName,
+                per_page: 50,
+              });
+
+              for (const run of runs) {
+                if (run.id === context.runId || run.status !== "completed") {
+                  continue;
+                }
+
+                const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                  owner,
+                  repo,
+                  run_id: run.id,
+                  per_page: 100,
+                });
+
+                const artifact = artifacts.data.artifacts.find(
+                  (entry) => entry.name === artifactName && !entry.expired,
+                );
+
+                if (artifact) {
+                  core.setOutput("baseline_run_id", String(run.id));
+                  core.setOutput("baseline_source", `${eventName}:${branch}`);
+                  return artifact.archive_download_url;
+                }
+              }
+
+              return "";
+            }
+
+            let url = "";
+            if (context.eventName === "pull_request" && context.payload.pull_request?.head?.ref) {
+              url = await findArtifactUrl(context.payload.pull_request.head.ref, "pull_request");
+            }
+
+            if (!url) {
+              url = await findArtifactUrl("main", "push");
+            }
+
+            core.setOutput("download_url", url);
+      - name: Download baseline matrix artifact
+        if: ${{ steps.baseline-matrix.outputs.download_url != '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          BASELINE_URL: ${{ steps.baseline-matrix.outputs.download_url }}
+        run: |
+          curl -fsSL \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -L "${BASELINE_URL}" \
+            -o .github-actionspec-dashboard/baseline/baseline.zip
+          unzip -q .github-actionspec-dashboard/baseline/baseline.zip -d .github-actionspec-dashboard/baseline
+      - name: Generate matrix dashboard
+        run: |
+          if [[ -f .github-actionspec-dashboard/baseline/validation-report.json ]]; then
+            just dashboard-report \
+              .github-actionspec-dashboard/current/validation-report.json \
+              .github-actionspec-dashboard/dashboard.md \
+              .github-actionspec-dashboard/baseline/validation-report.json
+          else
+            just dashboard-report \
+              .github-actionspec-dashboard/current/validation-report.json \
+              .github-actionspec-dashboard/dashboard.md
+          fi
+      - name: Add matrix dashboard to summary
+        run: cat .github-actionspec-dashboard/dashboard.md >> "${GITHUB_STEP_SUMMARY}"
+      - name: Upload matrix dashboard artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-matrix-dashboard
+          path: |
+            .github-actionspec-dashboard/current/validation-report.json
+            .github-actionspec-dashboard/dashboard.md
+      - name: Comment matrix on PR
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: actions/github-script@v8
+        env:
+          MATRIX_BASELINE_SOURCE: ${{ steps.baseline-matrix.outputs.baseline_source }}
+        with:
+          script: |
+            const fs = require("fs");
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const marker = "<!-- github-actionspec-matrix -->";
+            const dashboard = fs.readFileSync(".github-actionspec-dashboard/dashboard.md", "utf8");
+            const baselineSource = process.env.MATRIX_BASELINE_SOURCE;
+            const body = [
+              marker,
+              "## Workflow Matrix Dashboard",
+              baselineSource ? `Baseline: \`${baselineSource}\`` : "Baseline: `none`",
+              "",
+              dashboard,
+            ].join("\n");
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
       - name: Generate coverage
         run: just coverage-ci
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
           repo: .
           workflow: ci.yml
           actual: tests/fixtures/ci/passing
+          report-file: /github/runner_temp/github-actionspec-smoke/passing-dir-report.json
+          dashboard-file: /github/runner_temp/github-actionspec-smoke/passing-dir-dashboard.md
+          write-summary: false
       - name: Validate passing fixture list
         uses: ./
         with:
@@ -137,6 +140,9 @@ jobs:
           actual: |
             tests/fixtures/ci/ci-main-success.json
             tests/fixtures/ci/ci-main-pages.json
+          report-file: /github/runner_temp/github-actionspec-smoke/passing-list-report.json
+          dashboard-file: /github/runner_temp/github-actionspec-smoke/passing-list-dashboard.md
+          write-summary: false
       - name: Reject non-main workflow run
         id: wrong-ref
         continue-on-error: true
@@ -145,6 +151,9 @@ jobs:
           repo: .
           workflow: ci.yml
           actual: tests/fixtures/ci/ci-non-main-ref.json
+          report-file: /github/runner_temp/github-actionspec-smoke/wrong-ref-report.json
+          dashboard-file: /github/runner_temp/github-actionspec-smoke/wrong-ref-dashboard.md
+          write-summary: false
       - name: Reject skipped build on main
         id: skipped-build
         continue-on-error: true
@@ -153,6 +162,9 @@ jobs:
           repo: .
           workflow: ci.yml
           actual: tests/fixtures/ci/ci-build-skipped.json
+          report-file: /github/runner_temp/github-actionspec-smoke/skipped-build-report.json
+          dashboard-file: /github/runner_temp/github-actionspec-smoke/skipped-build-dashboard.md
+          write-summary: false
       - name: Validate expected smoke outcomes
         if: ${{ always() }}
         run: |
@@ -168,11 +180,11 @@ jobs:
             exit 1
           fi
       - name: Prepare matrix dashboard workspace
-        run: mkdir -p .github-actionspec-dashboard/current .github-actionspec-dashboard/baseline
+        run: mkdir -p "${{ runner.temp }}/github-actionspec-dashboard/current" "${{ runner.temp }}/github-actionspec-dashboard/baseline"
       - name: Generate current validation report
         id: current-matrix
         continue-on-error: true
-        run: just validate-repo-report . ci.yml tests/fixtures/ci .github-actionspec-dashboard/current/validation-report.json
+        run: just validate-repo-report . ci.yml tests/fixtures/ci "${{ runner.temp }}/github-actionspec-dashboard/current/validation-report.json"
       - name: Find baseline matrix artifact
         id: baseline-matrix
         uses: actions/github-script@v8
@@ -239,8 +251,8 @@ jobs:
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             -L "${BASELINE_URL}" \
-            -o .github-actionspec-dashboard/baseline/baseline.zip
-          unzip -q .github-actionspec-dashboard/baseline/baseline.zip -d .github-actionspec-dashboard/baseline
+            -o "${{ runner.temp }}/github-actionspec-dashboard/baseline/baseline.zip"
+          unzip -q "${{ runner.temp }}/github-actionspec-dashboard/baseline/baseline.zip" -d "${{ runner.temp }}/github-actionspec-dashboard/baseline"
       - name: Generate matrix dashboard through the action
         id: matrix-dashboard
         continue-on-error: true
@@ -249,9 +261,9 @@ jobs:
           repo: .
           workflow: ci.yml
           actual: tests/fixtures/ci
-          report-file: .github-actionspec-dashboard/current/validation-report.json
-          baseline-report: .github-actionspec-dashboard/baseline/validation-report.json
-          dashboard-file: .github-actionspec-dashboard/current/dashboard.md
+          report-file: /github/runner_temp/github-actionspec-dashboard/current/validation-report.json
+          baseline-report: /github/runner_temp/github-actionspec-dashboard/baseline/validation-report.json
+          dashboard-file: /github/runner_temp/github-actionspec-dashboard/current/dashboard.md
           comment-pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
           github-token: ${{ github.token }}
       - name: Upload matrix dashboard artifact
@@ -260,8 +272,8 @@ jobs:
         with:
           name: ci-matrix-dashboard
           path: |
-            .github-actionspec-dashboard/current/validation-report.json
-            .github-actionspec-dashboard/current/dashboard.md
+            ${{ runner.temp }}/github-actionspec-dashboard/current/validation-report.json
+            ${{ runner.temp }}/github-actionspec-dashboard/current/dashboard.md
       - name: Generate coverage
         run: just coverage-ci
       - name: Upload coverage to Codecov

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,4 +45,5 @@
 ## Validation
 - For code changes, run `just test`.
 - For CLI or discovery changes, also run `just discover`.
+- Before pushing a branch, make sure `just lint`, `just build`, and `just test` pass.
 - The default `just discover` target points to the current repository root.

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN GOBIN=/cue-bin go install cuelang.org/go/cmd/cue@${CUE_VERSION}
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update \
-    && apt-get install --yes --no-install-recommends ca-certificates \
+    && apt-get install --yes --no-install-recommends ca-certificates curl jq \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
@@ -34,5 +34,7 @@ WORKDIR /workspace
 COPY --from=runtime-builder /workspace/schema ./schema
 COPY --from=runtime-builder /workspace/target/release/github-actionspec /usr/local/bin/github-actionspec
 COPY --from=cue-builder /cue-bin/cue /usr/local/bin/cue
+COPY scripts/action/entrypoint.sh /usr/local/bin/github-actionspec-action
+RUN chmod +x /usr/local/bin/github-actionspec-action
 
 ENTRYPOINT ["github-actionspec"]

--- a/README.md
+++ b/README.md
@@ -42,13 +42,16 @@ just discover
 just coverage-summary
 just pr-create
 just validate-repo /path/to/repo ci.yml /path/to/actual.json
+just validate-repo-report /path/to/repo ci.yml /path/to/payloads target/actionspec/report.json
+just dashboard-report target/actionspec/report.json target/actionspec/dashboard.md
 ```
 
 Commands:
 
 - `github-actionspec discover --repo <path>`
 - `github-actionspec validate --schema <file> --schema <file> --contract <file> --actual <file-or-glob>`
-- `github-actionspec validate-repo --repo <path> [--workflow <name>] --actual <file-dir-or-glob>`
+- `github-actionspec validate-repo --repo <path> [--workflow <name>] --actual <file-dir-or-glob> [--report-file <report.json>]`
+- `github-actionspec dashboard --current <report.json> [--baseline <report.json>] --output <dashboard.md>`
 
 ## GitHub Action
 
@@ -153,9 +156,12 @@ GitHub Actions must call `just`, not raw `cargo`, `gh`, or `mise` command sequen
 - Build: `just build`
 - Lint: `just lint`
 - Test: `just test`
+- Matrix report: `just validate-repo-report . ci.yml tests/fixtures/ci target/actionspec/validation-report.json`
+- Matrix dashboard: `just dashboard-report target/actionspec/validation-report.json target/actionspec/dashboard.md`
 - Coverage upload: `just coverage-ci`
 - Local full pass: `just ci`
 - The remote action integration check now lives inside the main `CI` workflow and validates the published `v4lproik/github-actionspec-rs@main` action reference end to end against this repository's own `ci.yml` fixtures on pushes to `main`.
+- The `tests` job publishes a `ci-matrix-dashboard` artifact with the current validation report and a markdown matrix. On pull requests, the workflow also updates a single PR comment with that matrix and diffs it against the latest available baseline artifact.
 
 ## Docker Parity
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Inputs:
 - `workflow`: workflow file name to validate. Optional when the provided payloads all belong to the same workflow
 - `actual`: path to one normalized workflow run JSON payload, a directory containing JSON payloads, a glob pattern, or a newline-separated list of payloads and glob patterns. Defaults to `.github/actionspec-artifacts`
 - `declarations-dir`: custom declarations directory. Defaults to `.github/actionspec`
+- `report-file`: path where the action writes the JSON validation report. Defaults to `.github-actionspec-dashboard/current/validation-report.json`
+- `baseline-report`: optional path to a previous JSON validation report used to compute matrix diffs
+- `dashboard-file`: path where the action writes the markdown matrix dashboard. Defaults to `.github-actionspec-dashboard/current/dashboard.md`
+- `write-summary`: whether to append the matrix dashboard to the job summary. Defaults to `true`
+- `comment-pr`: whether to upsert the matrix dashboard as a PR comment. Defaults to `false`
+- `comment-title`: title used for the PR comment. Defaults to `Workflow Matrix Dashboard`
+- `comment-tag`: stable marker used to find and update the existing PR comment. Defaults to `github-actionspec-matrix`
+- `github-token`: token used for PR comment upserts when `comment-pr` is enabled
 
 Examples:
 
@@ -123,6 +131,42 @@ Examples:
     repo: .
     workflow: ci.yml
     actual: .github/actionspec-artifacts/**/*.json
+
+- name: Validate, diff against a previous report, and comment on the PR
+  id: actionspec
+  uses: v4lproik/github-actionspec-rs@main
+  with:
+    repo: .
+    workflow: ci.yml
+    actual: .github/actionspec-artifacts/**/*.json
+    report-file: .github-actionspec-dashboard/current/validation-report.json
+    baseline-report: .github-actionspec-dashboard/baseline/validation-report.json
+    dashboard-file: .github-actionspec-dashboard/current/dashboard.md
+    comment-pr: true
+    github-token: ${{ github.token }}
+
+- name: Upload the matrix artifact
+  uses: actions/upload-artifact@v4
+  with:
+    name: ci-matrix-dashboard
+    path: |
+      ${{ steps.actionspec.outputs.report-path }}
+      ${{ steps.actionspec.outputs.dashboard-path }}
+```
+
+To show the difference between the current and previous matrix, download the earlier report artifact before the action step and pass its report JSON through `baseline-report`. The action updates a single PR comment identified by `comment-tag`, so the discussion stays in one place instead of growing a new comment on every push.
+
+Example:
+
+```yaml
+- name: Download previous matrix artifact
+  uses: dawidd6/action-download-artifact@v9
+  with:
+    workflow: ci.yml
+    branch: main
+    name: ci-matrix-dashboard
+    path: .github-actionspec-dashboard/baseline
+    if_no_artifact_found: warn
 ```
 
 ## Coverage

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ Inputs:
 - `workflow`: workflow file name to validate. Optional when the provided payloads all belong to the same workflow
 - `actual`: path to one normalized workflow run JSON payload, a directory containing JSON payloads, a glob pattern, or a newline-separated list of payloads and glob patterns. Defaults to `.github/actionspec-artifacts`
 - `declarations-dir`: custom declarations directory. Defaults to `.github/actionspec`
-- `report-file`: path where the action writes the JSON validation report. Defaults to `.github-actionspec-dashboard/current/validation-report.json`
+- `report-file`: path where the action writes the JSON validation report. Defaults to `/github/runner_temp/github-actionspec-dashboard/current/validation-report.json`
 - `baseline-report`: optional path to a previous JSON validation report used to compute matrix diffs
-- `dashboard-file`: path where the action writes the markdown matrix dashboard. Defaults to `.github-actionspec-dashboard/current/dashboard.md`
+- `dashboard-file`: path where the action writes the markdown matrix dashboard. Defaults to `/github/runner_temp/github-actionspec-dashboard/current/dashboard.md`
 - `write-summary`: whether to append the matrix dashboard to the job summary. Defaults to `true`
 - `comment-pr`: whether to upsert the matrix dashboard as a PR comment. Defaults to `false`
 - `comment-title`: title used for the PR comment. Defaults to `Workflow Matrix Dashboard`
@@ -139,9 +139,9 @@ Examples:
     repo: .
     workflow: ci.yml
     actual: .github/actionspec-artifacts/**/*.json
-    report-file: .github-actionspec-dashboard/current/validation-report.json
-    baseline-report: .github-actionspec-dashboard/baseline/validation-report.json
-    dashboard-file: .github-actionspec-dashboard/current/dashboard.md
+    report-file: ${{ runner.temp }}/github-actionspec-dashboard/current/validation-report.json
+    baseline-report: ${{ runner.temp }}/github-actionspec-dashboard/baseline/validation-report.json
+    dashboard-file: ${{ runner.temp }}/github-actionspec-dashboard/current/dashboard.md
     comment-pr: true
     github-token: ${{ github.token }}
 
@@ -165,7 +165,7 @@ Example:
     workflow: ci.yml
     branch: main
     name: ci-matrix-dashboard
-    path: .github-actionspec-dashboard/baseline
+    path: ${{ runner.temp }}/github-actionspec-dashboard/baseline
     if_no_artifact_found: warn
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,10 @@
 name: github-actionspec validate-repo
 description: Validate a normalized GitHub Actions workflow run against a repository-owned CUE declaration.
+outputs:
+  report-path:
+    description: Path to the JSON validation report written by the action.
+  dashboard-path:
+    description: Path to the markdown dashboard written by the action.
 inputs:
   repo:
     description: Path to the target repository containing .github/actionspec declarations.
@@ -17,9 +22,42 @@ inputs:
     description: Path to the declarations directory inside the target repository.
     required: false
     default: .github/actionspec
+  report-file:
+    description: Path where the action should write the JSON validation report.
+    required: false
+    default: .github-actionspec-dashboard/current/validation-report.json
+  baseline-report:
+    description: Optional path to a previous JSON validation report used to render dashboard diffs.
+    required: false
+    default: ""
+  dashboard-file:
+    description: Path where the action should write the markdown matrix dashboard.
+    required: false
+    default: .github-actionspec-dashboard/current/dashboard.md
+  write-summary:
+    description: Whether to append the rendered dashboard to the GitHub Actions job summary.
+    required: false
+    default: "true"
+  comment-pr:
+    description: Whether to upsert the rendered dashboard as a PR comment when the workflow runs on a pull request.
+    required: false
+    default: "false"
+  comment-title:
+    description: Title used for the PR comment when comment-pr is enabled.
+    required: false
+    default: Workflow Matrix Dashboard
+  comment-tag:
+    description: Stable tag used to find and update the existing PR matrix comment.
+    required: false
+    default: github-actionspec-matrix
+  github-token:
+    description: GitHub token used for PR comment upserts when comment-pr is enabled.
+    required: false
+    default: ""
 runs:
   using: docker
   image: Dockerfile
+  entrypoint: /usr/local/bin/github-actionspec-action
   args:
     - validate-repo
     - --repo

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
   report-file:
     description: Path where the action should write the JSON validation report.
     required: false
-    default: .github-actionspec-dashboard/current/validation-report.json
+    default: /github/runner_temp/github-actionspec-dashboard/current/validation-report.json
   baseline-report:
     description: Optional path to a previous JSON validation report used to render dashboard diffs.
     required: false
@@ -33,7 +33,7 @@ inputs:
   dashboard-file:
     description: Path where the action should write the markdown matrix dashboard.
     required: false
-    default: .github-actionspec-dashboard/current/dashboard.md
+    default: /github/runner_temp/github-actionspec-dashboard/current/dashboard.md
   write-summary:
     description: Whether to append the rendered dashboard to the GitHub Actions job summary.
     required: false

--- a/justfile
+++ b/justfile
@@ -94,5 +94,13 @@ discover repo=".":
 validate-repo repo workflow actual:
   {{host-runner}} cargo run -- validate-repo --repo {{repo}} --workflow {{workflow}} --actual {{actual}}
 
+validate-repo-report repo workflow actual report:
+  just docker-build
+  {{docker-runner}} cargo run -- validate-repo --repo {{repo}} --workflow {{workflow}} --actual {{actual}} --report-file {{report}}
+
+dashboard-report current output baseline="":
+  just docker-build
+  if [ -n "{{baseline}}" ]; then {{docker-runner}} cargo run -- dashboard --current {{current}} --baseline {{baseline}} --output {{output}}; else {{docker-runner}} cargo run -- dashboard --current {{current}} --output {{output}}; fi
+
 validate schema contract actual:
   {{host-runner}} cargo run -- validate --schema {{schema}} --contract {{contract}} --actual {{actual}}

--- a/scripts/action/entrypoint.sh
+++ b/scripts/action/entrypoint.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+set -eu
+
+lower_bool() {
+  printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]'
+}
+
+write_outputs() {
+  if [ -z "${GITHUB_OUTPUT:-}" ]; then
+    return
+  fi
+
+  {
+    printf 'report-path=%s\n' "$REPORT_FILE"
+    printf 'dashboard-path=%s\n' "$DASHBOARD_FILE"
+  } >> "${GITHUB_OUTPUT}"
+}
+
+write_summary() {
+  if [ "$(lower_bool "${INPUT_WRITE_SUMMARY:-true}")" != "true" ] || [ -z "${GITHUB_STEP_SUMMARY:-}" ]; then
+    return
+  fi
+
+  cat "${DASHBOARD_FILE}" >> "${GITHUB_STEP_SUMMARY}"
+}
+
+upsert_pr_comment() {
+  if [ "$(lower_bool "${INPUT_COMMENT_PR:-false}")" != "true" ]; then
+    return
+  fi
+
+  if [ -z "${INPUT_GITHUB_TOKEN:-}" ] || [ -z "${GITHUB_REPOSITORY:-}" ] || [ -z "${GITHUB_EVENT_PATH:-}" ]; then
+    return
+  fi
+
+  pr_number="$(jq -r '.pull_request.number // empty' "${GITHUB_EVENT_PATH}")"
+  if [ -z "${pr_number}" ]; then
+    return
+  fi
+
+  marker="<!-- github-actionspec-matrix:${INPUT_COMMENT_TAG:-github-actionspec-matrix} -->"
+  title="${INPUT_COMMENT_TITLE:-Workflow Matrix Dashboard}"
+  payload="$(
+    {
+      printf '%s\n' "${marker}"
+      printf '## %s\n\n' "${title}"
+      cat "${DASHBOARD_FILE}"
+    } | jq -Rs '{body: .}'
+  )"
+
+  comments_json="$(
+    curl -fsSL \
+      -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments"
+  )"
+  comment_id="$(
+    printf '%s' "${comments_json}" |
+      jq -r --arg marker "${marker}" '[.[] | select(.body | contains($marker))][0].id // empty'
+  )"
+
+  if [ -n "${comment_id}" ]; then
+    curl -fsSL \
+      -X PATCH \
+      -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "Content-Type: application/json" \
+      "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+      -d "${payload}" >/dev/null
+  else
+    curl -fsSL \
+      -X POST \
+      -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "Content-Type: application/json" \
+      "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
+      -d "${payload}" >/dev/null
+  fi
+}
+
+REPORT_FILE="${INPUT_REPORT_FILE:-.github-actionspec-dashboard/current/validation-report.json}"
+DASHBOARD_FILE="${INPUT_DASHBOARD_FILE:-.github-actionspec-dashboard/current/dashboard.md}"
+BASELINE_REPORT="${INPUT_BASELINE_REPORT:-}"
+
+mkdir -p "$(dirname "${REPORT_FILE}")" "$(dirname "${DASHBOARD_FILE}")"
+
+set +e
+github-actionspec "$@" --report-file "${REPORT_FILE}"
+status=$?
+set -e
+
+if [ -f "${REPORT_FILE}" ]; then
+  if [ -n "${BASELINE_REPORT}" ] && [ -f "${BASELINE_REPORT}" ]; then
+    github-actionspec dashboard \
+      --current "${REPORT_FILE}" \
+      --baseline "${BASELINE_REPORT}" \
+      --output "${DASHBOARD_FILE}"
+  else
+    github-actionspec dashboard \
+      --current "${REPORT_FILE}" \
+      --output "${DASHBOARD_FILE}"
+  fi
+
+  write_outputs
+  write_summary
+  upsert_pr_comment
+fi
+
+exit "${status}"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,16 @@ pub enum Command {
         actual: Vec<PathBuf>,
         #[arg(long = "declarations-dir", default_value = ".github/actionspec")]
         declarations_dir: PathBuf,
+        #[arg(long = "report-file")]
+        report_file: Option<PathBuf>,
+    },
+    Dashboard {
+        #[arg(long)]
+        current: PathBuf,
+        #[arg(long)]
+        baseline: Option<PathBuf>,
+        #[arg(long)]
+        output: PathBuf,
     },
 }
 
@@ -144,11 +154,13 @@ mod tests {
                 workflow,
                 actual,
                 declarations_dir,
+                report_file,
             } => {
                 assert_eq!(repo, PathBuf::from("/tmp/repo"));
                 assert_eq!(workflow, Some("ci.yml".to_owned()));
                 assert_eq!(actual, vec![PathBuf::from("actual.json")]);
                 assert_eq!(declarations_dir, PathBuf::from(".github/actionspec"));
+                assert_eq!(report_file, None);
             }
             other => panic!("unexpected command: {other:?}"),
         }
@@ -172,11 +184,41 @@ mod tests {
                 workflow,
                 actual,
                 declarations_dir,
+                report_file,
             } => {
                 assert_eq!(repo, PathBuf::from("/tmp/repo"));
                 assert_eq!(workflow, None);
                 assert_eq!(actual, vec![PathBuf::from("actual.json")]);
                 assert_eq!(declarations_dir, PathBuf::from(".github/actionspec"));
+                assert_eq!(report_file, None);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_dashboard_command() {
+        let cli = Cli::try_parse_from([
+            "github-actionspec",
+            "dashboard",
+            "--current",
+            "current.json",
+            "--baseline",
+            "baseline.json",
+            "--output",
+            "dashboard.md",
+        ])
+        .expect("cli should parse");
+
+        match cli.command {
+            Command::Dashboard {
+                current,
+                baseline,
+                output,
+            } => {
+                assert_eq!(current, PathBuf::from("current.json"));
+                assert_eq!(baseline, Some(PathBuf::from("baseline.json")));
+                assert_eq!(output, PathBuf::from("dashboard.md"));
             }
             other => panic!("unexpected command: {other:?}"),
         }

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -1,0 +1,284 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+
+use crate::errors::AppError;
+use crate::types::{ActualValidationReport, ValidationReport, ValidationStatus};
+
+fn count_status(actuals: &[ActualValidationReport], status: ValidationStatus) -> usize {
+    actuals
+        .iter()
+        .filter(|actual| actual.status == status)
+        .count()
+}
+
+fn collect_job_names(
+    current: &ValidationReport,
+    baseline: Option<&ValidationReport>,
+) -> Vec<String> {
+    let mut job_names = BTreeSet::new();
+    for actual in &current.actuals {
+        job_names.extend(actual.jobs.keys().cloned());
+    }
+    if let Some(baseline) = baseline {
+        for actual in &baseline.actuals {
+            job_names.extend(actual.jobs.keys().cloned());
+        }
+    }
+    job_names.into_iter().collect()
+}
+
+fn compare_actual(
+    current: &ActualValidationReport,
+    baseline: Option<&ActualValidationReport>,
+) -> String {
+    let Some(baseline) = baseline else {
+        return "new".to_owned();
+    };
+
+    let mut changes = Vec::new();
+
+    if current.status != baseline.status {
+        changes.push(format!(
+            "status {:?}->{:?}",
+            baseline.status, current.status
+        ));
+    }
+
+    if current.ref_name != baseline.ref_name {
+        changes.push(format!(
+            "ref {}->{}",
+            baseline.ref_name.as_deref().unwrap_or("-"),
+            current.ref_name.as_deref().unwrap_or("-")
+        ));
+    }
+
+    let job_names = baseline
+        .jobs
+        .keys()
+        .chain(current.jobs.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    for job_name in job_names {
+        let before = baseline.jobs.get(&job_name);
+        let after = current.jobs.get(&job_name);
+        if before != after {
+            changes.push(format!(
+                "{} {}->{}",
+                job_name,
+                before.map(String::as_str).unwrap_or("-"),
+                after.map(String::as_str).unwrap_or("-")
+            ));
+        }
+    }
+
+    if changes.is_empty() {
+        "same".to_owned()
+    } else {
+        changes.join("; ")
+    }
+}
+
+pub fn load_validation_report(path: &Path) -> Result<ValidationReport, AppError> {
+    let contents = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&contents)?)
+}
+
+pub fn render_dashboard_markdown(
+    current: &ValidationReport,
+    baseline: Option<&ValidationReport>,
+) -> String {
+    let mut markdown = String::new();
+    let job_names = collect_job_names(current, baseline);
+
+    let _ = writeln!(markdown, "## Validation Matrix");
+    let _ = writeln!(markdown);
+    let _ = writeln!(markdown, "- Workflow: `{}`", current.workflow);
+    let _ = writeln!(
+        markdown,
+        "- Declaration: `{}`",
+        current.declaration_path.display()
+    );
+    let _ = writeln!(markdown, "- Current payloads: `{}`", current.actuals.len());
+    let _ = writeln!(
+        markdown,
+        "- Current passed: `{}`",
+        count_status(&current.actuals, ValidationStatus::Passed)
+    );
+    let _ = writeln!(
+        markdown,
+        "- Current failed: `{}`",
+        count_status(&current.actuals, ValidationStatus::Failed)
+    );
+
+    if let Some(baseline) = baseline {
+        let _ = writeln!(
+            markdown,
+            "- Baseline payloads: `{}`",
+            baseline.actuals.len()
+        );
+        let _ = writeln!(
+            markdown,
+            "- Baseline passed: `{}`",
+            count_status(&baseline.actuals, ValidationStatus::Passed)
+        );
+        let _ = writeln!(
+            markdown,
+            "- Baseline failed: `{}`",
+            count_status(&baseline.actuals, ValidationStatus::Failed)
+        );
+    }
+
+    let _ = writeln!(markdown);
+    let _ = write!(markdown, "| Payload | Ref | Status |");
+    for job_name in &job_names {
+        let _ = write!(markdown, " {} |", job_name);
+    }
+    let _ = writeln!(markdown, " Delta |");
+
+    let _ = write!(markdown, "| --- | --- | --- |");
+    for _ in &job_names {
+        let _ = write!(markdown, " --- |");
+    }
+    let _ = writeln!(markdown, " --- |");
+
+    let baseline_map = baseline.map(|report| {
+        report
+            .actuals
+            .iter()
+            .map(|actual| (actual.actual_path.clone(), actual))
+            .collect::<BTreeMap<_, _>>()
+    });
+
+    for actual in &current.actuals {
+        let _ = write!(
+            markdown,
+            "| `{}` | `{}` | `{:?}` |",
+            actual.actual_path.display(),
+            actual.ref_name.as_deref().unwrap_or("-"),
+            actual.status
+        );
+        for job_name in &job_names {
+            let value = actual.jobs.get(job_name).map(String::as_str).unwrap_or("-");
+            let _ = write!(markdown, " `{}` |", value);
+        }
+        let baseline_actual = baseline_map
+            .as_ref()
+            .and_then(|entries| entries.get(&actual.actual_path))
+            .copied();
+        let _ = writeln!(markdown, " {} |", compare_actual(actual, baseline_actual));
+    }
+
+    if let Some(baseline) = baseline {
+        let current_paths = current
+            .actuals
+            .iter()
+            .map(|actual| actual.actual_path.clone())
+            .collect::<BTreeSet<_>>();
+        let removed = baseline
+            .actuals
+            .iter()
+            .filter(|actual| !current_paths.contains(&actual.actual_path))
+            .collect::<Vec<_>>();
+
+        if !removed.is_empty() {
+            let _ = writeln!(markdown);
+            let _ = writeln!(markdown, "## Removed Since Baseline");
+            let _ = writeln!(markdown);
+            for actual in removed {
+                let _ = writeln!(markdown, "- `{}`", actual.actual_path.display());
+            }
+        }
+    }
+
+    markdown
+}
+
+pub fn write_dashboard_markdown(
+    current: &ValidationReport,
+    baseline: Option<&ValidationReport>,
+    output_path: &Path,
+) -> Result<(), AppError> {
+    fs::write(output_path, render_dashboard_markdown(current, baseline))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn actual(
+        path: &str,
+        ref_name: &str,
+        status: ValidationStatus,
+        jobs: &[(&str, &str)],
+    ) -> ActualValidationReport {
+        ActualValidationReport {
+            actual_path: PathBuf::from(path),
+            workflow: "ci.yml".to_owned(),
+            ref_name: Some(ref_name.to_owned()),
+            status,
+            jobs: jobs
+                .iter()
+                .map(|(job, result)| (job.to_string(), result.to_string()))
+                .collect(),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn renders_matrix_with_baseline_changes() {
+        let current = ValidationReport {
+            workflow: "ci.yml".to_owned(),
+            declaration_path: PathBuf::from(".github/actionspec/ci/main.cue"),
+            actuals: vec![
+                actual(
+                    "tests/fixtures/ci/ci-main-success.json",
+                    "main",
+                    ValidationStatus::Passed,
+                    &[("build", "success"), ("pages", "skipped")],
+                ),
+                actual(
+                    "tests/fixtures/ci/ci-build-skipped.json",
+                    "main",
+                    ValidationStatus::Failed,
+                    &[("build", "skipped"), ("pages", "skipped")],
+                ),
+            ],
+        };
+        let baseline = ValidationReport {
+            workflow: "ci.yml".to_owned(),
+            declaration_path: PathBuf::from(".github/actionspec/ci/main.cue"),
+            actuals: vec![
+                actual(
+                    "tests/fixtures/ci/ci-main-success.json",
+                    "main",
+                    ValidationStatus::Passed,
+                    &[("build", "success"), ("pages", "success")],
+                ),
+                actual(
+                    "tests/fixtures/ci/ci-removed.json",
+                    "main",
+                    ValidationStatus::Passed,
+                    &[("build", "success")],
+                ),
+            ],
+        };
+
+        let markdown = render_dashboard_markdown(&current, Some(&baseline));
+
+        assert!(markdown.contains("Validation Matrix"));
+        assert!(markdown.contains("ci-main-success.json"));
+        assert!(markdown.contains("pages success->skipped"));
+        assert!(
+            markdown.contains("| `tests/fixtures/ci/ci-build-skipped.json` | `main` | `Failed` |")
+        );
+        assert!(markdown.contains(" new |"));
+        assert!(markdown.contains("Removed Since Baseline"));
+        assert!(markdown.contains("ci-removed.json"));
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -39,6 +39,9 @@ pub enum AppError {
     #[error("No files matched actual glob pattern: {0}")]
     NoActualGlobMatches(String),
 
+    #[error("Validation failed for {failed} of {total} payloads.")]
+    ValidationFailures { failed: usize, total: usize },
+
     #[error(transparent)]
     GlobPattern(#[from] glob::PatternError),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod contracts;
+pub mod dashboard;
 pub mod discovery;
 pub mod errors;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 use clap::Parser;
 use github_actionspec_rs::cli::{Cli, Command};
+use github_actionspec_rs::dashboard::{load_validation_report, write_dashboard_markdown};
 use github_actionspec_rs::discovery::discover_declarations;
 use github_actionspec_rs::validate::{
-    validate_contract, validate_repo_workflow, ValidateContractOptions, ValidateRepoWorkflowOptions,
+    validate_contract, validate_repo_workflow, write_validation_report, ValidateContractOptions,
+    ValidateRepoWorkflowOptions,
 };
 use std::path::PathBuf;
 
@@ -57,15 +59,38 @@ fn run() -> Result<(), github_actionspec_rs::errors::AppError> {
             workflow,
             actual,
             declarations_dir,
+            report_file,
         } => {
-            validate_repo_workflow(ValidateRepoWorkflowOptions {
+            let result = validate_repo_workflow(ValidateRepoWorkflowOptions {
                 repo_root: repo,
                 workflow,
                 actual_paths: normalize_actual_inputs(actual),
                 declarations_dir,
+                report_file: report_file.clone(),
                 cwd: None,
                 env: None,
             })?;
+            if let Some(report_file) = report_file {
+                write_validation_report(&result.report, &report_file)?;
+            }
+            if result.failed_count > 0 {
+                return Err(github_actionspec_rs::errors::AppError::ValidationFailures {
+                    failed: result.failed_count,
+                    total: result.report.actuals.len(),
+                });
+            }
+        }
+        Command::Dashboard {
+            current,
+            baseline,
+            output,
+        } => {
+            let current = load_validation_report(&current)?;
+            let baseline = match baseline {
+                Some(path) => Some(load_validation_report(&path)?),
+                None => None,
+            };
+            write_dashboard_markdown(&current, baseline.as_ref(), &output)?;
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,3 +44,29 @@ pub struct WorkflowStepRecord {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub outputs: Option<BTreeMap<String, String>>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationStatus {
+    Passed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActualValidationReport {
+    pub actual_path: PathBuf,
+    pub workflow: String,
+    #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
+    pub ref_name: Option<String>,
+    pub status: ValidationStatus,
+    pub jobs: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidationReport {
+    pub workflow: String,
+    pub declaration_path: PathBuf,
+    pub actuals: Vec<ActualValidationReport>,
+}

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -8,7 +8,9 @@ use glob::glob;
 use crate::contracts::{declaration_schema_path, workflow_schema_path};
 use crate::discovery::find_declaration;
 use crate::errors::AppError;
-use crate::types::WorkflowRunEnvelope;
+use crate::types::{
+    ActualValidationReport, ValidationReport, ValidationStatus, WorkflowRunEnvelope,
+};
 
 #[derive(Debug, Clone)]
 pub struct ValidateContractOptions {
@@ -25,8 +27,15 @@ pub struct ValidateRepoWorkflowOptions {
     pub workflow: Option<String>,
     pub actual_paths: Vec<PathBuf>,
     pub declarations_dir: PathBuf,
+    pub report_file: Option<PathBuf>,
     pub cwd: Option<PathBuf>,
     pub env: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ValidateRepoWorkflowResult {
+    pub report: ValidationReport,
+    pub failed_count: usize,
 }
 
 fn assert_readable(path: &Path) -> Result<(), AppError> {
@@ -124,6 +133,11 @@ fn infer_workflow_from_actuals(paths: &[PathBuf]) -> Result<String, AppError> {
     ))
 }
 
+fn read_workflow_run(path: &Path) -> Result<WorkflowRunEnvelope, AppError> {
+    let contents = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&contents)?)
+}
+
 fn apply_env(command: &mut Command, env: &Option<HashMap<String, String>>) {
     if let Some(env_map) = env {
         // Tests and CI inject a controlled PATH for the fake `cue` binary, so the command must
@@ -162,6 +176,39 @@ pub fn assert_cue_available(env: &Option<HashMap<String, String>>) -> Result<(),
     }
 }
 
+fn run_cue_vet(
+    schema_paths: &[PathBuf],
+    contract_path: &Path,
+    actual_path: &Path,
+    cwd: Option<&Path>,
+    env: &Option<HashMap<String, String>>,
+) -> Result<(), String> {
+    let mut command = cue_command(env, cwd, "vet");
+    for schema_path in schema_paths {
+        command.arg(schema_path);
+    }
+    command.arg(contract_path);
+    command.arg(actual_path);
+
+    match command.output() {
+        Ok(output) if output.status.success() => Ok(()),
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            let code = output
+                .status
+                .code()
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unknown".to_owned());
+            if stderr.is_empty() {
+                Err(format!("cue vet failed with exit code {code}"))
+            } else {
+                Err(format!("cue vet failed with exit code {code}: {stderr}"))
+            }
+        }
+        Err(error) => Err(error.to_string()),
+    }
+}
+
 pub fn validate_contract(options: ValidateContractOptions) -> Result<(), AppError> {
     if options.schema_paths.is_empty() {
         return Err(AppError::MissingSchemaPaths);
@@ -175,50 +222,92 @@ pub fn validate_contract(options: ValidateContractOptions) -> Result<(), AppErro
     assert_cue_available(&options.env)?;
 
     for actual_path in &actual_paths {
-        let mut command = cue_command(&options.env, options.cwd.as_deref(), "vet");
-        for schema_path in &options.schema_paths {
-            command.arg(schema_path);
-        }
-        command.arg(&options.contract_path);
-        command.arg(actual_path);
-
-        let status = command.status()?;
-        if !status.success() {
-            return Err(AppError::CueVetFailed(
-                status
-                    .code()
-                    .map(|code| code.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned()),
-            ));
+        if let Err(error) = run_cue_vet(
+            &options.schema_paths,
+            &options.contract_path,
+            actual_path,
+            options.cwd.as_deref(),
+            &options.env,
+        ) {
+            return Err(AppError::CueVetFailed(error));
         }
     }
 
     Ok(())
 }
 
-pub fn validate_repo_workflow(options: ValidateRepoWorkflowOptions) -> Result<(), AppError> {
+pub fn write_validation_report(report: &ValidationReport, path: &Path) -> Result<(), AppError> {
+    fs::write(path, serde_json::to_string_pretty(report)?)?;
+    Ok(())
+}
+
+pub fn validate_repo_workflow(
+    options: ValidateRepoWorkflowOptions,
+) -> Result<ValidateRepoWorkflowResult, AppError> {
     let ValidateRepoWorkflowOptions {
         repo_root,
         workflow,
         actual_paths,
         declarations_dir,
+        report_file: _,
         cwd,
         env,
     } = options;
 
+    let actual_paths = resolve_actual_paths(&actual_paths)?;
     let workflow = match workflow {
         Some(workflow) if !workflow.trim().is_empty() => workflow,
-        _ => infer_workflow_from_actuals(&resolve_actual_paths(&actual_paths)?)?,
+        _ => infer_workflow_from_actuals(&actual_paths)?,
     };
 
     let declaration = find_declaration(&repo_root, &workflow, Some(&declarations_dir))?;
+    assert_cue_available(&env)?;
 
-    validate_contract(ValidateContractOptions {
-        schema_paths: vec![workflow_schema_path(), declaration_schema_path()],
-        contract_path: declaration.declaration_path,
-        actual_paths,
-        cwd,
-        env,
+    let mut actual_reports = Vec::new();
+    let mut failed = 0;
+
+    for actual_path in actual_paths {
+        let envelope = read_workflow_run(&actual_path)?;
+        let jobs = envelope
+            .run
+            .jobs
+            .into_iter()
+            .map(|(job_name, job)| (job_name, job.result))
+            .collect();
+        let cue_result = run_cue_vet(
+            &[workflow_schema_path(), declaration_schema_path()],
+            &declaration.declaration_path,
+            &actual_path,
+            cwd.as_deref(),
+            &env,
+        );
+        let (status, error) = match cue_result {
+            Ok(()) => (ValidationStatus::Passed, None),
+            Err(error) => {
+                failed += 1;
+                (ValidationStatus::Failed, Some(error))
+            }
+        };
+
+        actual_reports.push(ActualValidationReport {
+            actual_path,
+            workflow: envelope.run.workflow,
+            ref_name: envelope.run.ref_name,
+            status,
+            jobs,
+            error,
+        });
+    }
+
+    let report = ValidationReport {
+        workflow,
+        declaration_path: declaration.declaration_path,
+        actuals: actual_reports,
+    };
+
+    Ok(ValidateRepoWorkflowResult {
+        report,
+        failed_count: failed,
     })
 }
 
@@ -335,6 +424,7 @@ mod tests {
             workflow: Some("missing.yml".to_owned()),
             actual_paths: vec![actual],
             declarations_dir: PathBuf::from(".github/actionspec"),
+            report_file: None,
             cwd: None,
             env: None,
         })
@@ -414,15 +504,19 @@ mod tests {
             "#!/bin/sh\nif [ \"$1\" = \"version\" ]; then\n  exit 0\nfi\nif [ \"$1\" = \"vet\" ]; then\n  exit 0\nfi\nexit 1\n",
         );
 
-        validate_repo_workflow(ValidateRepoWorkflowOptions {
+        let result = validate_repo_workflow(ValidateRepoWorkflowOptions {
             repo_root: temp.path().to_path_buf(),
             workflow: None,
             actual_paths: vec![actual],
             declarations_dir: PathBuf::from(".github/actionspec"),
+            report_file: None,
             cwd: None,
             env: Some(env),
         })
         .expect("validation should succeed");
+
+        assert_eq!(result.failed_count, 0);
+        assert_eq!(result.report.actuals.len(), 1);
     }
 
     #[test]
@@ -446,6 +540,7 @@ mod tests {
             workflow: None,
             actual_paths: vec![first, second],
             declarations_dir: PathBuf::from(".github/actionspec"),
+            report_file: None,
             cwd: None,
             env: None,
         })
@@ -456,6 +551,62 @@ mod tests {
             .contains("Could not infer a single workflow from the provided actual payloads"));
         assert!(error.to_string().contains("build.yml"));
         assert!(error.to_string().contains("deploy.yml"));
+    }
+
+    #[test]
+    fn validate_repo_workflow_collects_failures_in_report() {
+        let temp = tempdir().expect("temp dir should be created");
+        let declaration_dir = temp.path().join(".github/actionspec/ci");
+        fs::create_dir_all(&declaration_dir).expect("declaration dir should be created");
+        fs::write(
+            declaration_dir.join("main.cue"),
+            "package actionspec\n\nworkflow: \"ci.yml\"\n\nrun: #Declaration.run & {\n  workflow: workflow\n  ref: \"main\"\n  jobs: {\n    build: {\n      result: \"success\"\n    }\n  }\n}\n",
+        )
+        .expect("declaration should be written");
+
+        let passing = temp.path().join("passing.json");
+        let failing = temp.path().join("failing.json");
+        fs::write(
+            &passing,
+            "{\"run\":{\"workflow\":\"ci.yml\",\"ref\":\"main\",\"jobs\":{\"build\":{\"result\":\"success\"}}}}",
+        )
+        .expect("passing actual should be written");
+        fs::write(
+            &failing,
+            "{\"run\":{\"workflow\":\"ci.yml\",\"ref\":\"main\",\"jobs\":{\"build\":{\"result\":\"skipped\"}}}}",
+        )
+        .expect("failing actual should be written");
+
+        let env = install_fake_cue(
+            temp.path(),
+            "#!/bin/sh\nif [ \"$1\" = \"version\" ]; then\n  exit 0\nfi\nif [ \"$1\" = \"vet\" ]; then\n  last=\"\"\n  for arg in \"$@\"; do\n    last=\"$arg\"\n  done\n  case \"$last\" in\n    *passing.json) exit 0 ;;\n    *failing.json) echo \"build should not be skipped\" >&2; exit 9 ;;\n  esac\nfi\nexit 1\n",
+        );
+
+        let result = validate_repo_workflow(ValidateRepoWorkflowOptions {
+            repo_root: temp.path().to_path_buf(),
+            workflow: Some("ci.yml".to_owned()),
+            actual_paths: vec![passing.clone(), failing.clone()],
+            declarations_dir: PathBuf::from(".github/actionspec"),
+            report_file: None,
+            cwd: None,
+            env: Some(env),
+        })
+        .expect("report should be produced");
+
+        assert_eq!(result.failed_count, 1);
+        assert_eq!(result.report.actuals.len(), 2);
+        assert!(result
+            .report
+            .actuals
+            .iter()
+            .any(|actual| actual.actual_path == passing && actual.error.is_none()));
+        assert!(result.report.actuals.iter().any(|actual| {
+            actual.actual_path == failing
+                && actual
+                    .error
+                    .as_ref()
+                    .is_some_and(|error| error.contains("build should not be skipped"))
+        }));
     }
 
     #[test]

--- a/tests/action_entrypoint.rs
+++ b/tests/action_entrypoint.rs
@@ -1,0 +1,179 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn write_executable(path: &std::path::Path, contents: &str) {
+    fs::write(path, contents).unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+#[test]
+fn action_entrypoint_writes_dashboard_outputs_and_updates_pr_comment() {
+    let temp = tempdir().unwrap();
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+
+    write_executable(
+        &bin_dir.join("github-actionspec"),
+        r#"#!/bin/sh
+set -eu
+cmd="$1"
+shift
+if [ "$cmd" = "validate-repo" ]; then
+  report_file=""
+  prev=""
+  for arg in "$@"; do
+    if [ "$prev" = "--report-file" ]; then
+      report_file="$arg"
+    fi
+    prev="$arg"
+  done
+  mkdir -p "$(dirname "$report_file")"
+  cat > "$report_file" <<'EOF'
+{
+  "workflow": "ci.yml",
+  "declaration_path": ".github/actionspec/ci/main.cue",
+  "actuals": [
+    {
+      "actual_path": "tests/fixtures/ci/ci-main-success.json",
+      "workflow": "ci.yml",
+      "ref": "main",
+      "status": "passed",
+      "jobs": {
+        "build": "success",
+        "pages": "skipped"
+      }
+    }
+  ]
+}
+EOF
+  exit 0
+fi
+if [ "$cmd" = "dashboard" ]; then
+  output=""
+  prev=""
+  for arg in "$@"; do
+    if [ "$prev" = "--output" ]; then
+      output="$arg"
+    fi
+    prev="$arg"
+  done
+  mkdir -p "$(dirname "$output")"
+  cat > "$output" <<'EOF'
+## Validation Matrix
+
+| Payload | Ref | Status | build | pages | Delta |
+| --- | --- | --- | --- | --- | --- |
+| `tests/fixtures/ci/ci-main-success.json` | `main` | `Passed` | `success` | `skipped` | same |
+EOF
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    write_executable(
+        &bin_dir.join("jq"),
+        r#"#!/bin/sh
+set -eu
+case "$*" in
+  *".pull_request.number // empty"*)
+    echo "42"
+    ;;
+  *"contains("*)
+    echo "123"
+    ;;
+  *"{body: .}"*)
+    cat >/dev/null
+    echo '{"body":"mock"}'
+    ;;
+  *)
+    cat
+    ;;
+esac
+"#,
+    );
+
+    write_executable(
+        &bin_dir.join("curl"),
+        r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${CURL_LOG}"
+case "$*" in
+  *"/issues/42/comments"*"-X PATCH"*)
+    echo '{}'
+    ;;
+  *"/issues/comments/123"*)
+    echo '{}'
+    ;;
+  *"/issues/42/comments"*)
+    echo '[]'
+    ;;
+  *)
+    echo '{}'
+    ;;
+esac
+"#,
+    );
+
+    let report_file = temp
+        .path()
+        .join(".github-actionspec-dashboard/current/validation-report.json");
+    let dashboard_file = temp
+        .path()
+        .join(".github-actionspec-dashboard/current/dashboard.md");
+    let output_file = temp.path().join("github_output.txt");
+    let summary_file = temp.path().join("step_summary.md");
+    let event_file = temp.path().join("event.json");
+    let curl_log = temp.path().join("curl.log");
+
+    fs::write(&event_file, r#"{"pull_request":{"number":42}}"#).unwrap();
+    fs::write(&curl_log, "").unwrap();
+
+    let status = Command::new("/bin/sh")
+        .arg("scripts/action/entrypoint.sh")
+        .arg("validate-repo")
+        .arg("--repo")
+        .arg(".")
+        .arg("--workflow")
+        .arg("ci.yml")
+        .arg("--actual")
+        .arg("tests/fixtures/ci/ci-main-success.json")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .env(
+            "PATH",
+            format!("{}:{}", bin_dir.display(), std::env::var("PATH").unwrap()),
+        )
+        .env("INPUT_REPORT_FILE", &report_file)
+        .env("INPUT_DASHBOARD_FILE", &dashboard_file)
+        .env("INPUT_COMMENT_PR", "true")
+        .env("INPUT_COMMENT_TITLE", "Workflow Matrix Dashboard")
+        .env("INPUT_COMMENT_TAG", "test-matrix")
+        .env("INPUT_GITHUB_TOKEN", "token")
+        .env("GITHUB_OUTPUT", &output_file)
+        .env("GITHUB_STEP_SUMMARY", &summary_file)
+        .env("GITHUB_EVENT_PATH", &event_file)
+        .env("GITHUB_REPOSITORY", "v4lproik/github-actionspec-rs")
+        .env("CURL_LOG", &curl_log)
+        .status()
+        .unwrap();
+
+    assert!(status.success());
+    assert!(report_file.exists());
+    assert!(dashboard_file.exists());
+
+    let outputs = fs::read_to_string(&output_file).unwrap();
+    assert!(outputs.contains(&format!("report-path={}", report_file.display())));
+    assert!(outputs.contains(&format!("dashboard-path={}", dashboard_file.display())));
+
+    let summary = fs::read_to_string(&summary_file).unwrap();
+    assert!(summary.contains("Validation Matrix"));
+
+    let curl_log = fs::read_to_string(&curl_log).unwrap();
+    assert!(curl_log.contains("/issues/42/comments"));
+    assert!(curl_log.contains("/issues/comments/123"));
+}

--- a/tests/dashboard.rs
+++ b/tests/dashboard.rs
@@ -1,0 +1,74 @@
+use assert_cmd::Command;
+use github_actionspec_rs::types::{ActualValidationReport, ValidationReport, ValidationStatus};
+use tempfile::tempdir;
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+fn actual(path: &str, status: ValidationStatus, jobs: &[(&str, &str)]) -> ActualValidationReport {
+    ActualValidationReport {
+        actual_path: PathBuf::from(path),
+        workflow: "ci.yml".to_owned(),
+        ref_name: Some("main".to_owned()),
+        status,
+        jobs: jobs
+            .iter()
+            .map(|(name, result)| (name.to_string(), result.to_string()))
+            .collect::<BTreeMap<_, _>>(),
+        error: None,
+    }
+}
+
+#[test]
+fn dashboard_cli_writes_markdown_with_diff() {
+    let temp = tempdir().unwrap();
+    let current = temp.path().join("current.json");
+    let baseline = temp.path().join("baseline.json");
+    let output = temp.path().join("dashboard.md");
+
+    std::fs::write(
+        &current,
+        serde_json::to_string_pretty(&ValidationReport {
+            workflow: "ci.yml".to_owned(),
+            declaration_path: PathBuf::from(".github/actionspec/ci/main.cue"),
+            actuals: vec![actual(
+                "tests/fixtures/ci/ci-main-pages.json",
+                ValidationStatus::Passed,
+                &[("build", "success"), ("pages", "success")],
+            )],
+        })
+        .unwrap(),
+    )
+    .unwrap();
+    std::fs::write(
+        &baseline,
+        serde_json::to_string_pretty(&ValidationReport {
+            workflow: "ci.yml".to_owned(),
+            declaration_path: PathBuf::from(".github/actionspec/ci/main.cue"),
+            actuals: vec![actual(
+                "tests/fixtures/ci/ci-main-pages.json",
+                ValidationStatus::Failed,
+                &[("build", "skipped"), ("pages", "skipped")],
+            )],
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    let mut command = Command::cargo_bin("github-actionspec").unwrap();
+    command
+        .arg("dashboard")
+        .arg("--current")
+        .arg(&current)
+        .arg("--baseline")
+        .arg(&baseline)
+        .arg("--output")
+        .arg(&output);
+
+    command.assert().success();
+
+    let markdown = std::fs::read_to_string(output).unwrap();
+    assert!(markdown.contains("Validation Matrix"));
+    assert!(markdown.contains("status Failed->Passed"));
+    assert!(markdown.contains("build skipped->success"));
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -53,17 +53,18 @@ pub fn write_validation_fixture(
 }
 
 pub fn install_fake_cue(temp_dir: &TempDir, mode: &str) -> HashMap<String, String> {
-    let bin_dir = temp_dir.path().join("bin");
+    let script = format!(
+        "#!/bin/sh\nif [ \"$1\" = \"version\" ]; then\n  exit 0\nfi\nif [ \"$1\" = \"vet\" ]; then\n  if [ \"{mode}\" = \"success\" ]; then\n    exit 0\n  fi\n  exit 9\nfi\nexit 1\n"
+    );
+    install_fake_cue_script(temp_dir.path(), &script)
+}
+
+pub fn install_fake_cue_script(temp_root: &Path, script: &str) -> HashMap<String, String> {
+    let bin_dir = temp_root.join("bin");
     fs::create_dir_all(&bin_dir).unwrap();
     let cue_path = bin_dir.join("cue");
     // Keep the shim minimal: tests only need `cue version` and `cue vet` to behave predictably.
-    fs::write(
-        &cue_path,
-        format!(
-            "#!/bin/sh\nif [ \"$1\" = \"version\" ]; then\n  exit 0\nfi\nif [ \"$1\" = \"vet\" ]; then\n  if [ \"{mode}\" = \"success\" ]; then\n    exit 0\n  fi\n  exit 9\nfi\nexit 1\n"
-        ),
-    )
-    .unwrap();
+    fs::write(&cue_path, script).unwrap();
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/tests/validate_repo.rs
+++ b/tests/validate_repo.rs
@@ -1,6 +1,7 @@
 mod support;
 
 use assert_cmd::Command;
+use github_actionspec_rs::types::ValidationReport;
 use predicates::prelude::*;
 use tempfile::tempdir;
 
@@ -145,4 +146,52 @@ fn discovers_repo_contracts_through_cli() {
         .stdout(predicate::str::contains(
             ".github/actionspec/release/default.cue",
         ));
+}
+
+#[test]
+fn writes_report_file_before_failing_validation() {
+    let repo = tempdir().unwrap();
+    support::write_declaration(repo.path(), ".github/actionspec/ci/main.cue", "ci.yml");
+    let passing = repo.path().join("ci-main-success.json");
+    let failing = repo.path().join("ci-main-skipped.json");
+    std::fs::write(
+        &passing,
+        "{\"run\":{\"workflow\":\"ci.yml\",\"ref\":\"main\",\"jobs\":{\"build\":{\"result\":\"success\"}}}}",
+    )
+    .unwrap();
+    std::fs::write(
+        &failing,
+        "{\"run\":{\"workflow\":\"ci.yml\",\"ref\":\"main\",\"jobs\":{\"build\":{\"result\":\"skipped\"}}}}",
+    )
+    .unwrap();
+    let report = repo.path().join("validation-report.json");
+    let env = support::install_fake_cue_script(
+        repo.path(),
+        "#!/bin/sh\nif [ \"$1\" = \"version\" ]; then\n  exit 0\nfi\nif [ \"$1\" = \"vet\" ]; then\n  last=\"\"\n  for arg in \"$@\"; do\n    last=\"$arg\"\n  done\n  case \"$last\" in\n    *ci-main-success.json) exit 0 ;;\n    *ci-main-skipped.json) echo \"build should not be skipped\" >&2; exit 9 ;;\n  esac\nfi\nexit 1\n",
+    );
+
+    let mut command = Command::cargo_bin("github-actionspec").unwrap();
+    command
+        .envs(env)
+        .arg("validate-repo")
+        .arg("--repo")
+        .arg(repo.path())
+        .arg("--workflow")
+        .arg("ci.yml")
+        .arg("--actual")
+        .arg(&passing)
+        .arg("--actual")
+        .arg(&failing)
+        .arg("--report-file")
+        .arg(&report);
+
+    command.assert().failure().stderr(predicate::str::contains(
+        "Validation failed for 1 of 2 payloads.",
+    ));
+
+    let report: ValidationReport =
+        serde_json::from_str(&std::fs::read_to_string(report).unwrap()).unwrap();
+    assert_eq!(report.actuals.len(), 2);
+    assert!(report.actuals.iter().any(|actual| actual.error.as_deref()
+        == Some("cue vet failed with exit code 9: build should not be skipped")));
 }


### PR DESCRIPTION
## Summary
Add a compact workflow validation matrix that can be generated locally, published as a CI artifact, and upserted into pull requests as a single dashboard comment.

## What Changed
- added structured `validate-repo` reporting via `--report-file`
- added a `dashboard` command that renders a markdown matrix from current and baseline reports
- added `just validate-repo-report` and `just dashboard-report`
- updated the `tests` job to publish a `ci-matrix-dashboard` artifact
- updated pull requests to upsert a single matrix comment and show diffs against the latest available baseline matrix
- added tests for report generation and dashboard rendering

## Why
Engineers need a readable view of how workflow behavior changed across representative payloads without digging through raw validation logs.

## Validation
- `just fmt`
- `just test`
- `just discover`