### PR TITLE
test(ci): validate outputs and summarize matrix in PR comments (#21)

### DIFF
--- a/.github/actionspec/ci/main.cue
+++ b/.github/actionspec/ci/main.cue
@@ -2,6 +2,10 @@ package actionspec
 
 workflow: "ci.yml"
 
+let detectChanges = run.jobs["detect-changes"]
+let runCI = detectChanges.outputs.run_ci
+let runPages = detectChanges.outputs.run_pages
+
 run: #Declaration.run & {
   workflow: workflow
   ref:      "main"
@@ -9,27 +13,66 @@ run: #Declaration.run & {
   jobs: {
     "detect-changes": {
       result: "success"
+      outputs: {
+        run_ci:    "true" | "false"
+        run_pages: "true" | "false"
+      }
     }
 
-    lint: {
-      result: "success"
+    if runCI == "true" {
+      lint: {
+        result: "success"
+      }
+
+      build: {
+        result: "success"
+      }
+
+      tests: {
+        result: "success"
+      }
+
+      docker: {
+        result: "success"
+      }
     }
 
-    build: {
-      result: "success"
+    if runCI == "false" {
+      lint: {
+        result: "skipped"
+      }
+
+      build: {
+        result: "skipped"
+      }
+
+      tests: {
+        result: "skipped"
+      }
+
+      docker: {
+        result: "skipped"
+      }
     }
 
-    tests: {
-      result: "success"
+    if runPages == "true" {
+      pages: {
+        result: "success"
+      }
     }
 
-    docker: {
-      result: "success"
+    if runPages == "false" {
+      pages: {
+        result: "skipped"
+      }
     }
 
-    // Pages only runs for docs changes on pushes to main.
-    pages: {
-      result: "success" | "skipped"
+    if runPages == "true" {
+      "detect-changes": {
+        outputs: {
+          run_ci: "true"
+        }
+      }
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
           actual: |
             tests/fixtures/ci/ci-main-success.json
             tests/fixtures/ci/ci-main-pages.json
+            tests/fixtures/ci/ci-main-noop.json
           report-file: /github/runner_temp/github-actionspec-smoke/passing-list-report.json
           dashboard-file: /github/runner_temp/github-actionspec-smoke/passing-list-dashboard.md
           write-summary: false
@@ -165,6 +166,28 @@ jobs:
           report-file: /github/runner_temp/github-actionspec-smoke/skipped-build-report.json
           dashboard-file: /github/runner_temp/github-actionspec-smoke/skipped-build-dashboard.md
           write-summary: false
+      - name: Reject pages run that stays skipped
+        id: skipped-pages
+        continue-on-error: true
+        uses: ./
+        with:
+          repo: .
+          workflow: ci.yml
+          actual: tests/fixtures/ci/ci-pages-enabled-but-skipped.json
+          report-file: /github/runner_temp/github-actionspec-smoke/skipped-pages-report.json
+          dashboard-file: /github/runner_temp/github-actionspec-smoke/skipped-pages-dashboard.md
+          write-summary: false
+      - name: Reject downstream jobs when run_ci is false
+        id: run-ci-disabled
+        continue-on-error: true
+        uses: ./
+        with:
+          repo: .
+          workflow: ci.yml
+          actual: tests/fixtures/ci/ci-run-ci-disabled-build-ran.json
+          report-file: /github/runner_temp/github-actionspec-smoke/run-ci-disabled-report.json
+          dashboard-file: /github/runner_temp/github-actionspec-smoke/run-ci-disabled-dashboard.md
+          write-summary: false
       - name: Validate expected smoke outcomes
         if: ${{ always() }}
         run: |
@@ -177,6 +200,16 @@ jobs:
 
           if [[ "${{ steps.skipped-build.outcome }}" != "failure" ]]; then
             echo "::error::The skipped build fixture should fail validation."
+            exit 1
+          fi
+
+          if [[ "${{ steps.skipped-pages.outcome }}" != "failure" ]]; then
+            echo "::error::The skipped pages fixture should fail validation."
+            exit 1
+          fi
+
+          if [[ "${{ steps.run-ci-disabled.outcome }}" != "failure" ]]; then
+            echo "::error::The run_ci=false fixture should fail when downstream jobs run."
             exit 1
           fi
       - name: Prepare matrix dashboard workspace
@@ -307,6 +340,7 @@ jobs:
           actual: |
             tests/fixtures/ci/ci-main-success.json
             tests/fixtures/ci/ci-main-pages.json
+            tests/fixtures/ci/ci-main-noop.json
       - name: Reject non-main workflow run
         id: wrong-ref
         continue-on-error: true
@@ -323,6 +357,22 @@ jobs:
           repo: .
           workflow: ci.yml
           actual: tests/fixtures/ci/ci-build-skipped.json
+      - name: Reject pages run that stays skipped
+        id: skipped-pages
+        continue-on-error: true
+        uses: v4lproik/github-actionspec-rs@main
+        with:
+          repo: .
+          workflow: ci.yml
+          actual: tests/fixtures/ci/ci-pages-enabled-but-skipped.json
+      - name: Reject downstream jobs when run_ci is false
+        id: run-ci-disabled
+        continue-on-error: true
+        uses: v4lproik/github-actionspec-rs@main
+        with:
+          repo: .
+          workflow: ci.yml
+          actual: tests/fixtures/ci/ci-run-ci-disabled-build-ran.json
       - name: Validate expected plugin outcomes
         if: ${{ always() }}
         run: |
@@ -337,6 +387,16 @@ jobs:
             echo "::error::The skipped build fixture should fail validation."
             exit 1
           fi
+
+          if [[ "${{ steps.skipped-pages.outcome }}" != "failure" ]]; then
+            echo "::error::The skipped pages fixture should fail validation."
+            exit 1
+          fi
+
+          if [[ "${{ steps.run-ci-disabled.outcome }}" != "failure" ]]; then
+            echo "::error::The run_ci=false fixture should fail when downstream jobs run."
+            exit 1
+          fi
       - name: Summarize remote action integration
         if: ${{ always() }}
         run: |
@@ -347,9 +407,12 @@ jobs:
           - Passing file list:
             - `ci-main-success.json`
             - `ci-main-pages.json`
+            - `ci-main-noop.json`
           - Expected failing fixtures:
             - `ci-non-main-ref.json`
             - `ci-build-skipped.json`
+            - `ci-pages-enabled-but-skipped.json`
+            - `ci-run-ci-disabled-build-ran.json`
           EOF
 
   docker:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Inputs:
 - `baseline-report`: optional path to a previous JSON validation report used to compute matrix diffs
 - `dashboard-file`: path where the action writes the markdown matrix dashboard. Defaults to `/github/runner_temp/github-actionspec-dashboard/current/dashboard.md`
 - `write-summary`: whether to append the matrix dashboard to the job summary. Defaults to `true`
-- `comment-pr`: whether to upsert the matrix dashboard as a PR comment. Defaults to `false`
+- `comment-pr`: whether to upsert a PR comment containing a short validation summary and the full matrix dashboard. Defaults to `false`
 - `comment-title`: title used for the PR comment. Defaults to `Workflow Matrix Dashboard`
 - `comment-tag`: stable marker used to find and update the existing PR comment. Defaults to `github-actionspec-matrix`
 - `github-token`: token used for PR comment upserts when `comment-pr` is enabled
@@ -154,7 +154,7 @@ Examples:
       ${{ steps.actionspec.outputs.dashboard-path }}
 ```
 
-To show the difference between the current and previous matrix, download the earlier report artifact before the action step and pass its report JSON through `baseline-report`. The action updates a single PR comment identified by `comment-tag`, so the discussion stays in one place instead of growing a new comment on every push.
+To show the difference between the current and previous matrix, download the earlier report artifact before the action step and pass its report JSON through `baseline-report`. The action updates a single PR comment identified by `comment-tag`, with a short status summary followed by the full matrix, so the discussion stays in one place instead of growing a new comment on every push.
 
 Example:
 

--- a/scripts/action/entrypoint.sh
+++ b/scripts/action/entrypoint.sh
@@ -24,6 +24,37 @@ write_summary() {
   cat "${DASHBOARD_FILE}" >> "${GITHUB_STEP_SUMMARY}"
 }
 
+report_stat() {
+  report_path="$1"
+  status_name="$2"
+  jq -r --arg status_name "${status_name}" '[.actuals[] | select(.status == $status_name)] | length' "${report_path}"
+}
+
+render_pr_summary() {
+  current_total="$(jq -r '.actuals | length' "${REPORT_FILE}")"
+  current_passed="$(report_stat "${REPORT_FILE}" "passed")"
+  current_failed="$(report_stat "${REPORT_FILE}" "failed")"
+  workflow_name="$(jq -r '.workflow' "${REPORT_FILE}")"
+  declaration_path="$(jq -r '.declaration_path' "${REPORT_FILE}")"
+
+  printf -- '- Workflow: `%s`\n' "${workflow_name}"
+  printf -- '- Declaration: `%s`\n' "${declaration_path}"
+  printf -- '- Current: `%s` payloads, `%s` passed, `%s` failed\n' \
+    "${current_total}" "${current_passed}" "${current_failed}"
+
+  if [ -n "${BASELINE_REPORT}" ] && [ -f "${BASELINE_REPORT}" ]; then
+    baseline_total="$(jq -r '.actuals | length' "${BASELINE_REPORT}")"
+    baseline_passed="$(report_stat "${BASELINE_REPORT}" "passed")"
+    baseline_failed="$(report_stat "${BASELINE_REPORT}" "failed")"
+
+    printf -- '- Baseline: `%s` payloads, `%s` passed, `%s` failed\n' \
+      "${baseline_total}" "${baseline_passed}" "${baseline_failed}"
+    printf -- '- Delta: passed `%+d`, failed `%+d`\n' \
+      "$((current_passed - baseline_passed))" \
+      "$((current_failed - baseline_failed))"
+  fi
+}
+
 upsert_pr_comment() {
   if [ "$(lower_bool "${INPUT_COMMENT_PR:-false}")" != "true" ]; then
     return
@@ -44,6 +75,8 @@ upsert_pr_comment() {
     {
       printf '%s\n' "${marker}"
       printf '## %s\n\n' "${title}"
+      render_pr_summary
+      printf '\n'
       cat "${DASHBOARD_FILE}"
     } | jq -Rs '{body: .}'
   )"

--- a/tests/action_entrypoint.rs
+++ b/tests/action_entrypoint.rs
@@ -81,6 +81,28 @@ exit 1
         r#"#!/bin/sh
 set -eu
 case "$*" in
+  *".workflow"*)
+    echo "ci.yml"
+    ;;
+  *".declaration_path"*)
+    echo ".github/actionspec/ci/main.cue"
+    ;;
+  *".actuals | length"*)
+    echo "1"
+    ;;
+  *'.actuals[] | select(.status == $status_name)] | length'*)
+    case "$*" in
+      *"passed"*)
+        echo "1"
+        ;;
+      *"failed"*)
+        echo "0"
+        ;;
+      *)
+        echo "0"
+        ;;
+    esac
+    ;;
   *".pull_request.number // empty"*)
     echo "42"
     ;;
@@ -88,7 +110,8 @@ case "$*" in
     echo "123"
     ;;
   *"{body: .}"*)
-    cat >/dev/null
+    payload="$(cat)"
+    printf '%s\n' "${payload}" > "${JQ_BODY_LOG}"
     echo '{"body":"mock"}'
     ;;
   *)
@@ -130,9 +153,11 @@ esac
     let summary_file = temp.path().join("step_summary.md");
     let event_file = temp.path().join("event.json");
     let curl_log = temp.path().join("curl.log");
+    let jq_body_log = temp.path().join("jq-body.log");
 
     fs::write(&event_file, r#"{"pull_request":{"number":42}}"#).unwrap();
     fs::write(&curl_log, "").unwrap();
+    fs::write(&jq_body_log, "").unwrap();
 
     let status = Command::new("/bin/sh")
         .arg("scripts/action/entrypoint.sh")
@@ -159,6 +184,7 @@ esac
         .env("GITHUB_EVENT_PATH", &event_file)
         .env("GITHUB_REPOSITORY", "v4lproik/github-actionspec-rs")
         .env("CURL_LOG", &curl_log)
+        .env("JQ_BODY_LOG", &jq_body_log)
         .status()
         .unwrap();
 
@@ -176,4 +202,8 @@ esac
     let curl_log = fs::read_to_string(&curl_log).unwrap();
     assert!(curl_log.contains("/issues/42/comments"));
     assert!(curl_log.contains("/issues/comments/123"));
+
+    let comment_body = fs::read_to_string(&jq_body_log).unwrap();
+    assert!(comment_body.contains("Current: `1` payloads, `1` passed, `0` failed"));
+    assert!(comment_body.contains("## Validation Matrix"));
 }

--- a/tests/fixtures/ci/ci-build-skipped.json
+++ b/tests/fixtures/ci/ci-build-skipped.json
@@ -4,7 +4,11 @@
     "ref": "main",
     "jobs": {
       "detect-changes": {
-        "result": "success"
+        "result": "success",
+        "outputs": {
+          "run_ci": "true",
+          "run_pages": "false"
+        }
       },
       "lint": {
         "result": "success"

--- a/tests/fixtures/ci/ci-main-noop.json
+++ b/tests/fixtures/ci/ci-main-noop.json
@@ -1,26 +1,26 @@
 {
   "run": {
     "workflow": "ci.yml",
-    "ref": "feature/self-hosted-fixtures",
+    "ref": "main",
     "jobs": {
       "detect-changes": {
         "result": "success",
         "outputs": {
-          "run_ci": "true",
+          "run_ci": "false",
           "run_pages": "false"
         }
       },
       "lint": {
-        "result": "success"
+        "result": "skipped"
       },
       "build": {
-        "result": "success"
+        "result": "skipped"
       },
       "tests": {
-        "result": "success"
+        "result": "skipped"
       },
       "docker": {
-        "result": "success"
+        "result": "skipped"
       },
       "pages": {
         "result": "skipped"

--- a/tests/fixtures/ci/ci-pages-enabled-but-skipped.json
+++ b/tests/fixtures/ci/ci-pages-enabled-but-skipped.json
@@ -1,13 +1,13 @@
 {
   "run": {
     "workflow": "ci.yml",
-    "ref": "feature/self-hosted-fixtures",
+    "ref": "main",
     "jobs": {
       "detect-changes": {
         "result": "success",
         "outputs": {
           "run_ci": "true",
-          "run_pages": "false"
+          "run_pages": "true"
         }
       },
       "lint": {

--- a/tests/fixtures/ci/ci-run-ci-disabled-build-ran.json
+++ b/tests/fixtures/ci/ci-run-ci-disabled-build-ran.json
@@ -1,12 +1,12 @@
 {
   "run": {
     "workflow": "ci.yml",
-    "ref": "feature/self-hosted-fixtures",
+    "ref": "main",
     "jobs": {
       "detect-changes": {
         "result": "success",
         "outputs": {
-          "run_ci": "true",
+          "run_ci": "false",
           "run_pages": "false"
         }
       },

--- a/tests/fixtures/ci/passing/ci-main-noop.json
+++ b/tests/fixtures/ci/passing/ci-main-noop.json
@@ -1,26 +1,26 @@
 {
   "run": {
     "workflow": "ci.yml",
-    "ref": "feature/self-hosted-fixtures",
+    "ref": "main",
     "jobs": {
       "detect-changes": {
         "result": "success",
         "outputs": {
-          "run_ci": "true",
+          "run_ci": "false",
           "run_pages": "false"
         }
       },
       "lint": {
-        "result": "success"
+        "result": "skipped"
       },
       "build": {
-        "result": "success"
+        "result": "skipped"
       },
       "tests": {
-        "result": "success"
+        "result": "skipped"
       },
       "docker": {
-        "result": "success"
+        "result": "skipped"
       },
       "pages": {
         "result": "skipped"


### PR DESCRIPTION
## Summary
Tighten the CI contract to validate detect-changes outputs and make PR matrix comments easier to scan.

## What Changed
- validate run_ci and run_pages behavior in .github/actionspec/ci/main.cue
- add passing and failing CI fixtures for output-gated workflow states
- extend workflow smoke tests to cover those fixture combinations
- prepend PR matrix comments with a compact summary before the full matrix
- document the PR comment behavior in README.md

## Validation
- just lint
- just build
- just test
- just discover