### PR TITLE
test(integration): add real cue coverage (#36)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+FROM golang:1.24-bookworm AS cue-builder
+
+ARG CUE_VERSION=v0.15.0
+RUN GOBIN=/cue-bin go install cuelang.org/go/cmd/cue@${CUE_VERSION}
+
 FROM rust:1.85.0-bookworm AS dev
 
 ARG CARGO_LLVM_COV_VERSION=0.6.15
@@ -6,6 +11,7 @@ ARG CARGO_LLVM_COV_VERSION=0.6.15
 # development and CI execute against the same Rust environment.
 RUN rustup component add clippy rustfmt llvm-tools \
     && cargo install --locked cargo-llvm-cov --version "${CARGO_LLVM_COV_VERSION}"
+COPY --from=cue-builder /cue-bin/cue /usr/local/bin/cue
 
 WORKDIR /workspace
 
@@ -16,11 +22,6 @@ COPY Cargo.toml Cargo.lock ./
 COPY schema ./schema
 COPY src ./src
 RUN cargo build --locked --release
-
-FROM golang:1.24-bookworm AS cue-builder
-
-ARG CUE_VERSION=v0.15.0
-RUN GOBIN=/cue-bin go install cuelang.org/go/cmd/cue@${CUE_VERSION}
 
 FROM debian:bookworm-slim AS runtime
 

--- a/tests/real_cue.rs
+++ b/tests/real_cue.rs
@@ -1,0 +1,111 @@
+use std::path::{Path, PathBuf};
+
+use github_actionspec_rs::validate::{validate_contract, ValidateContractOptions};
+use tempfile::tempdir;
+
+fn repo_schema_path(path: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
+}
+
+fn write_contract(path: &Path, contract_build: &str) {
+    std::fs::write(
+        path,
+        format!(
+            r#"package actionspec
+
+workflow: "build.yml"
+
+run: #Declaration.run & {{
+  workflow: workflow
+  jobs: {{
+    build: {{
+      result: "success"
+      matrix: {{
+        app: "build-ts-service"
+        target: "linux-amd64"
+      }}
+      outputs: {{
+        contract_build: "{contract_build}"
+      }}
+    }}
+  }}
+}}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+fn write_actual(path: &Path, contract_build: &str) {
+    std::fs::write(
+        path,
+        format!(
+            r#"{{
+  "run": {{
+    "workflow": "build.yml",
+    "jobs": {{
+      "build": {{
+        "result": "success",
+        "matrix": {{
+          "app": "build-ts-service",
+          "target": "linux-amd64"
+        }},
+        "outputs": {{
+          "contract_build": "{contract_build}"
+        }}
+      }}
+    }}
+  }}
+}}"#
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn real_cue_validates_matrix_and_outputs_against_repo_schema() {
+    let temp = tempdir().unwrap();
+    let contract = temp.path().join("contract.cue");
+    let actual = temp.path().join("actual.json");
+    write_contract(&contract, "build-ts-service");
+    write_actual(&actual, "build-ts-service");
+
+    let result = validate_contract(ValidateContractOptions {
+        schema_paths: vec![
+            repo_schema_path("schema/workflow_run.cue"),
+            repo_schema_path("schema/declaration.cue"),
+        ],
+        contract_path: contract,
+        actual_paths: vec![actual],
+        cwd: Some(temp.path().to_path_buf()),
+        env: None,
+    });
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn real_cue_rejects_diverging_matrix_and_output_values() {
+    let temp = tempdir().unwrap();
+    let contract = temp.path().join("contract.cue");
+    let actual = temp.path().join("actual.json");
+    write_contract(&contract, "build-ts-service");
+    write_actual(&actual, "contract-build");
+
+    let error = validate_contract(ValidateContractOptions {
+        schema_paths: vec![
+            repo_schema_path("schema/workflow_run.cue"),
+            repo_schema_path("schema/declaration.cue"),
+        ],
+        contract_path: contract,
+        actual_paths: vec![actual],
+        cwd: Some(temp.path().to_path_buf()),
+        env: None,
+    })
+    .unwrap_err();
+
+    let message = error.to_string();
+    assert!(message.contains("cue vet failed"));
+    assert!(message.contains("contract_build"));
+    assert!(message.contains("build-ts-service"));
+}


### PR DESCRIPTION
## Summary
- add real CUE integration tests that validate contracts against the repository schemas
- install the real cue binary in the dev image so Docker-backed lint/build/test runs cover the actual toolchain
- keep the fake-shim tests and add real-toolchain coverage for the matrix/output path

## Verification
- just lint
- just build
- just test