### PR TITLE
test(validate): expand matrix and output coverage (#35)

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -27,29 +27,44 @@ pub fn write_actual(path: &Path, workflow: &str) {
     .unwrap();
 }
 
-pub fn write_validation_fixture(
+pub fn write_json_validation_fixture(
     temp_root: &Path,
-    workflow: &str,
+    schema_contents: &str,
+    contract_contents: &str,
+    actual_contents: &serde_json::Value,
 ) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
     let schema = temp_root.join("schema.cue");
     let contract = temp_root.join("contract.cue");
     let actual = temp_root.join("actual.json");
 
-    std::fs::write(
-        &schema,
-        "package actionspec\n#WorkflowRun: {workflow: string, jobs: [string]: {result: string}}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        &contract,
-        format!(
-            "package actionspec\nrun: #WorkflowRun & {{workflow: \"{workflow}\", jobs: {{build: {{result: \"success\"}}}}}}\n"
-        ),
-    )
-    .unwrap();
-    write_actual(&actual, workflow);
+    std::fs::write(&schema, schema_contents).unwrap();
+    std::fs::write(&contract, contract_contents).unwrap();
+    std::fs::write(&actual, serde_json::to_string(actual_contents).unwrap()).unwrap();
 
     (schema, contract, actual)
+}
+
+pub fn write_validation_fixture(
+    temp_root: &Path,
+    workflow: &str,
+) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+    write_json_validation_fixture(
+        temp_root,
+        "package actionspec\n#WorkflowRun: {workflow: string, jobs: [string]: {result: string}}\n",
+        &format!(
+            "package actionspec\nrun: #WorkflowRun & {{workflow: \"{workflow}\", jobs: {{build: {{result: \"success\"}}}}}}\n"
+        ),
+        &serde_json::json!({
+            "run": {
+                "workflow": workflow,
+                "jobs": {
+                    "sample": {
+                        "result": "success",
+                    }
+                }
+            }
+        }),
+    )
 }
 
 pub fn write_matrix_output_validation_fixture(
@@ -58,25 +73,13 @@ pub fn write_matrix_output_validation_fixture(
     app: &str,
     contract_build: &str,
 ) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
-    let schema = temp_root.join("schema.cue");
-    let contract = temp_root.join("contract.cue");
-    let actual = temp_root.join("actual.json");
-
-    std::fs::write(
-        &schema,
+    write_json_validation_fixture(
+        temp_root,
         "package actionspec\n#WorkflowRun: {\n  workflow: string\n  jobs: [string]: {\n    result: string\n    outputs?: [string]: string\n    matrix?: [string]: string | bool | number | null\n  }\n}\n",
-    )
-    .unwrap();
-    std::fs::write(
-        &contract,
-        format!(
+        &format!(
             "package actionspec\nrun: #WorkflowRun & {{\n  workflow: \"{workflow}\"\n  jobs: {{\n    build: {{\n      result: \"success\"\n      matrix: {{\n        app: \"{app}\"\n      }}\n      outputs: {{\n        contract_build: \"{contract_build}\"\n      }}\n    }}\n  }}\n}}\n"
         ),
-    )
-    .unwrap();
-    std::fs::write(
-        &actual,
-        serde_json::to_string(&serde_json::json!({
+        &serde_json::json!({
             "run": {
                 "workflow": workflow,
                 "jobs": {
@@ -91,12 +94,8 @@ pub fn write_matrix_output_validation_fixture(
                     }
                 }
             }
-        }))
-        .unwrap(),
+        }),
     )
-    .unwrap();
-
-    (schema, contract, actual)
 }
 
 pub fn install_fake_cue(temp_dir: &TempDir, mode: &str) -> HashMap<String, String> {

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -6,6 +6,10 @@ use assert_cmd::Command;
 use github_actionspec_rs::validate::{validate_contract, ValidateContractOptions};
 use tempfile::tempdir;
 
+fn matrix_output_schema() -> &'static str {
+    "package actionspec\n#WorkflowRun: {\n  workflow: string\n  jobs: [string]: {\n    result: string\n    outputs?: [string]: string\n    matrix?: [string]: string | bool | number | null\n  }\n}\n"
+}
+
 fn write_cross_job_fixture(
     temp_root: &Path,
     build_tag: &str,
@@ -271,6 +275,318 @@ exit 1
     assert!(error
         .to_string()
         .contains("matrix app build-ts-service must match outputs.contract_build contract-build",));
+}
+
+#[test]
+fn validates_contract_with_multiple_jobs_and_matrix_axes() {
+    let temp = tempdir().unwrap();
+    let (schema, contract, actual) = support::write_json_validation_fixture(
+        temp.path(),
+        matrix_output_schema(),
+        r#"package actionspec
+run: #WorkflowRun & {
+  workflow: "build.yml"
+  jobs: {
+    build: {
+      result: "success"
+      matrix: {
+        app: "build-ts-service"
+        target: "linux-amd64"
+        shard: 2
+        release: true
+      }
+      outputs: {
+        contract_build: "build-ts-service"
+      }
+    }
+    publish: {
+      result: "success"
+      outputs: {
+        image_tag: "v1.2.3"
+      }
+    }
+  }
+}
+"#,
+        &serde_json::json!({
+            "run": {
+                "workflow": "build.yml",
+                "jobs": {
+                    "build": {
+                        "result": "success",
+                        "matrix": {
+                            "app": "build-ts-service",
+                            "target": "linux-amd64",
+                            "shard": 2,
+                            "release": true,
+                        },
+                        "outputs": {
+                            "contract_build": "build-ts-service",
+                        },
+                    },
+                    "publish": {
+                        "result": "success",
+                        "outputs": {
+                            "image_tag": "v1.2.3",
+                        },
+                    },
+                }
+            }
+        }),
+    );
+
+    let env = support::install_fake_cue_script(
+        temp.path(),
+        r#"#!/bin/sh
+set -eu
+if [ "$1" = "version" ]; then
+  exit 0
+fi
+if [ "$1" = "vet" ]; then
+  last=""
+  contract=""
+  for arg in "$@"; do
+    contract="$last"
+    last="$arg"
+  done
+
+  grep -q 'target: "linux-amd64"' "$contract"
+  grep -q 'shard: 2' "$contract"
+  grep -q 'release: true' "$contract"
+  grep -q 'image_tag: "v1.2.3"' "$contract"
+  grep -q '"target":"linux-amd64"' "$last"
+  grep -q '"shard":2' "$last"
+  grep -q '"release":true' "$last"
+  grep -q '"image_tag":"v1.2.3"' "$last"
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    let result = validate_contract(ValidateContractOptions {
+        schema_paths: vec![schema],
+        contract_path: contract,
+        actual_paths: vec![actual],
+        cwd: Some(temp.path().to_path_buf()),
+        env: Some(env),
+    });
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn validates_contract_when_optional_outputs_are_omitted() {
+    let temp = tempdir().unwrap();
+    let (schema, contract, actual) = support::write_json_validation_fixture(
+        temp.path(),
+        matrix_output_schema(),
+        r#"package actionspec
+run: #WorkflowRun & {
+  workflow: "build.yml"
+  jobs: {
+    build: {
+      result: "success"
+      matrix: {
+        app: "build-ts-service"
+      }
+    }
+  }
+}
+"#,
+        &serde_json::json!({
+            "run": {
+                "workflow": "build.yml",
+                "jobs": {
+                    "build": {
+                        "result": "success",
+                        "matrix": {
+                            "app": "build-ts-service",
+                        },
+                    },
+                }
+            }
+        }),
+    );
+
+    let env = support::install_fake_cue_script(
+        temp.path(),
+        r#"#!/bin/sh
+set -eu
+if [ "$1" = "version" ]; then
+  exit 0
+fi
+if [ "$1" = "vet" ]; then
+  last=""
+  for arg in "$@"; do
+    last="$arg"
+  done
+
+  grep -q '"app":"build-ts-service"' "$last"
+  if grep -q '"outputs"' "$last"; then
+    echo "outputs should be omitted for this payload" >&2
+    exit 9
+  fi
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    let result = validate_contract(ValidateContractOptions {
+        schema_paths: vec![schema],
+        contract_path: contract,
+        actual_paths: vec![actual],
+        cwd: Some(temp.path().to_path_buf()),
+        env: Some(env),
+    });
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn fails_when_required_matrix_key_is_missing() {
+    let temp = tempdir().unwrap();
+    let (schema, contract, actual) = support::write_json_validation_fixture(
+        temp.path(),
+        matrix_output_schema(),
+        r#"package actionspec
+run: #WorkflowRun & {
+  workflow: "build.yml"
+  jobs: {
+    build: {
+      result: "success"
+      matrix: {
+        app: "build-ts-service"
+        target: "linux-amd64"
+      }
+    }
+  }
+}
+"#,
+        &serde_json::json!({
+            "run": {
+                "workflow": "build.yml",
+                "jobs": {
+                    "build": {
+                        "result": "success",
+                        "matrix": {
+                            "app": "build-ts-service",
+                        },
+                    },
+                }
+            }
+        }),
+    );
+
+    let env = support::install_fake_cue_script(
+        temp.path(),
+        r#"#!/bin/sh
+set -eu
+if [ "$1" = "version" ]; then
+  exit 0
+fi
+if [ "$1" = "vet" ]; then
+  last=""
+  contract=""
+  for arg in "$@"; do
+    contract="$last"
+    last="$arg"
+  done
+
+  if grep -q 'target: "linux-amd64"' "$contract" && ! grep -q '"target":"linux-amd64"' "$last"; then
+    echo "missing matrix.target for jobs.build" >&2
+    exit 9
+  fi
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    let error = validate_contract(ValidateContractOptions {
+        schema_paths: vec![schema],
+        contract_path: contract,
+        actual_paths: vec![actual],
+        cwd: Some(temp.path().to_path_buf()),
+        env: Some(env),
+    })
+    .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("missing matrix.target for jobs.build"));
+}
+
+#[test]
+fn fails_when_required_output_key_is_missing() {
+    let temp = tempdir().unwrap();
+    let (schema, contract, actual) = support::write_json_validation_fixture(
+        temp.path(),
+        matrix_output_schema(),
+        r#"package actionspec
+run: #WorkflowRun & {
+  workflow: "build.yml"
+  jobs: {
+    build: {
+      result: "success"
+      outputs: {
+        contract_build: "build-ts-service"
+      }
+    }
+  }
+}
+"#,
+        &serde_json::json!({
+            "run": {
+                "workflow": "build.yml",
+                "jobs": {
+                    "build": {
+                        "result": "success",
+                        "outputs": {},
+                    },
+                }
+            }
+        }),
+    );
+
+    let env = support::install_fake_cue_script(
+        temp.path(),
+        r#"#!/bin/sh
+set -eu
+if [ "$1" = "version" ]; then
+  exit 0
+fi
+if [ "$1" = "vet" ]; then
+  last=""
+  contract=""
+  for arg in "$@"; do
+    contract="$last"
+    last="$arg"
+  done
+
+  if grep -q 'contract_build: "build-ts-service"' "$contract" && ! grep -q '"contract_build":"build-ts-service"' "$last"; then
+    echo "missing outputs.contract_build for jobs.build" >&2
+    exit 9
+  fi
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    let error = validate_contract(ValidateContractOptions {
+        schema_paths: vec![schema],
+        contract_path: contract,
+        actual_paths: vec![actual],
+        cwd: Some(temp.path().to_path_buf()),
+        env: Some(env),
+    })
+    .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("missing outputs.contract_build for jobs.build"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add generic validation-fixture helpers for richer workflow payload shapes
- cover multi-job and multi-axis matrix payloads, including numeric and boolean matrix values
- add failure cases for missing matrix and output keys, plus optional-output coverage

## Verification
- just lint
- just build
- just test