### PR TITLE
feat(validate): improve validation diagnostics (#38)

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -39,8 +39,12 @@ pub enum AppError {
     #[error("No files matched actual glob pattern: {0}")]
     NoActualGlobMatches(String),
 
-    #[error("Validation failed for {failed} of {total} payloads.")]
-    ValidationFailures { failed: usize, total: usize },
+    #[error("Validation failed for {failed} of {total} payloads.\n{details}")]
+    ValidationFailures {
+        failed: usize,
+        total: usize,
+        details: String,
+    },
 
     #[error(transparent)]
     GlobPattern(#[from] glob::PatternError),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use github_actionspec_rs::cli::{Cli, Command};
 use github_actionspec_rs::dashboard::{load_validation_report, write_dashboard_markdown};
 use github_actionspec_rs::discovery::discover_declarations;
+use github_actionspec_rs::types::ValidationStatus;
 use github_actionspec_rs::validate::{
     validate_contract, validate_repo_workflow, write_validation_report, ValidateContractOptions,
     ValidateRepoWorkflowOptions,
@@ -28,6 +29,25 @@ fn normalize_actual_inputs(actuals: Vec<PathBuf>) -> Vec<PathBuf> {
                 .collect::<Vec<_>>()
         })
         .collect()
+}
+
+fn summarize_validation_failures(report: &github_actionspec_rs::types::ValidationReport) -> String {
+    report
+        .actuals
+        .iter()
+        .filter(|actual| actual.status == ValidationStatus::Failed)
+        .map(|actual| {
+            format!(
+                "- {}: {}",
+                actual.actual_path.display(),
+                actual
+                    .error
+                    .as_deref()
+                    .unwrap_or("validation failed without a reported cue error")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn run() -> Result<(), github_actionspec_rs::errors::AppError> {
@@ -77,6 +97,7 @@ fn run() -> Result<(), github_actionspec_rs::errors::AppError> {
                 return Err(github_actionspec_rs::errors::AppError::ValidationFailures {
                     failed: result.failed_count,
                     total: result.report.actuals.len(),
+                    details: summarize_validation_failures(&result.report),
                 });
             }
         }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -199,14 +199,45 @@ fn run_cue_vet(
                 .code()
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "unknown".to_owned());
-            if stderr.is_empty() {
-                Err(format!("cue vet failed with exit code {code}"))
-            } else {
-                Err(format!("cue vet failed with exit code {code}: {stderr}"))
-            }
+            Err(format_cue_vet_failure(actual_path, &code, &stderr))
         }
         Err(error) => Err(error.to_string()),
     }
+}
+
+fn format_cue_vet_failure(actual_path: &Path, code: &str, stderr: &str) -> String {
+    let prefix = format!(
+        "cue vet failed for {} with exit code {code}",
+        actual_path.display()
+    );
+
+    if stderr.is_empty() {
+        return prefix;
+    }
+
+    if let Some((field, left, right)) = extract_conflicting_values(stderr) {
+        return format!(
+            "{prefix}: field {field} has conflicting values {left} and {right}; raw cue stderr: {stderr}"
+        );
+    }
+
+    format!("{prefix}: {stderr}")
+}
+
+fn extract_conflicting_values(stderr: &str) -> Option<(String, String, String)> {
+    let first_line = stderr
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())?;
+    let (field, values) = first_line.split_once(": conflicting values ")?;
+    let values = values.trim_end_matches(':');
+    let (left, right) = values.rsplit_once(" and ")?;
+
+    Some((
+        field.trim().to_owned(),
+        left.trim().to_owned(),
+        right.trim().to_owned(),
+    ))
 }
 
 pub fn validate_contract(options: ValidateContractOptions) -> Result<(), AppError> {

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -100,15 +100,16 @@ fn fails_when_cue_vet_fails() {
     let error = validate_contract(ValidateContractOptions {
         schema_paths: vec![schema],
         contract_path: contract,
-        actual_paths: vec![actual],
+        actual_paths: vec![actual.clone()],
         cwd: Some(temp.path().to_path_buf()),
         env: Some(env),
     })
     .unwrap_err();
 
-    assert!(error
-        .to_string()
-        .contains("cue vet failed with exit code 9"));
+    let message = error.to_string();
+    assert!(message.contains("cue vet failed for"));
+    assert!(message.contains(&actual.display().to_string()));
+    assert!(message.contains("with exit code 9"));
 }
 
 #[test]
@@ -183,7 +184,7 @@ if [ "$1" = "vet" ]; then
   app_value="$(grep -o '"app":"[^"]*"' "$last" | head -n1 | cut -d'"' -f4)"
   contract_build_value="$(grep -o '"contract_build":"[^"]*"' "$last" | head -n1 | cut -d'"' -f4)"
   if [ "${app_value}" != "${contract_build_value}" ]; then
-    echo "matrix app ${app_value} must match outputs.contract_build ${contract_build_value}" >&2
+    echo "run.jobs.build.outputs.contract_build: conflicting values \"${app_value}\" and \"${contract_build_value}\"" >&2
     exit 9
   fi
   exit 0
@@ -195,13 +196,14 @@ exit 1
     let error = validate_contract(ValidateContractOptions {
         schema_paths: vec![schema],
         contract_path: contract,
-        actual_paths: vec![actual],
+        actual_paths: vec![actual.clone()],
         cwd: Some(temp.path().to_path_buf()),
         env: Some(env),
     })
     .unwrap_err();
 
-    assert!(error
-        .to_string()
-        .contains("matrix app build-ts-service must match outputs.contract_build contract-build",));
+    let message = error.to_string();
+    assert!(message.contains(&actual.display().to_string()));
+    assert!(message.contains("field run.jobs.build.outputs.contract_build"));
+    assert!(message.contains("conflicting values \"build-ts-service\" and \"contract-build\""));
 }

--- a/tests/validate_repo.rs
+++ b/tests/validate_repo.rs
@@ -185,13 +185,27 @@ fn writes_report_file_before_failing_validation() {
         .arg("--report-file")
         .arg(&report);
 
-    command.assert().failure().stderr(predicate::str::contains(
-        "Validation failed for 1 of 2 payloads.",
-    ));
+    command
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Validation failed for 1 of 2 payloads.",
+        ))
+        .stderr(predicate::str::contains(failing.display().to_string()))
+        .stderr(predicate::str::contains("build should not be skipped"));
 
     let report: ValidationReport =
         serde_json::from_str(&std::fs::read_to_string(report).unwrap()).unwrap();
     assert_eq!(report.actuals.len(), 2);
-    assert!(report.actuals.iter().any(|actual| actual.error.as_deref()
-        == Some("cue vet failed with exit code 9: build should not be skipped")));
+    assert!(report.actuals.iter().any(|actual| {
+        actual.actual_path == failing
+            && actual
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("cue vet failed for"))
+            && actual
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("build should not be skipped"))
+    }));
 }


### PR DESCRIPTION
## Summary
- include the failing payload path in cue vet failures
- surface parsed conflicting-value details when cue reports a field mismatch
- include per-payload failure lines in validate-repo CLI stderr instead of only the aggregate count

## Verification
- just lint
- just build
- just test