### PR TITLE
docs(validate): support cross-job invariants (#34)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN cargo build --locked --release
 
 FROM golang:1.24-bookworm AS cue-builder
 
-ARG CUE_VERSION=v0.15.0
+ARG CUE_VERSION
 RUN GOBIN=/cue-bin go install cuelang.org/go/cmd/cue@${CUE_VERSION}
 
 FROM debian:bookworm-slim AS runtime

--- a/README.md
+++ b/README.md
@@ -116,6 +116,32 @@ If the workflow emits a different output for that same matrix entry, validation 
 }
 ```
 
+Cross-job invariants work the same way. This contract says the `publish` job must reuse the exact image tag emitted by `build`:
+
+```cue
+package actionspec
+
+run: #WorkflowRun & {
+  workflow: "release.yml"
+  jobs: {
+    build: {
+      result: "success"
+      outputs: {
+        image_tag: string
+      }
+    }
+    publish: {
+      result: "success"
+      outputs: {
+        published_tag: run.jobs.build.outputs.image_tag
+      }
+    }
+  }
+}
+```
+
+That pattern is useful when one workflow job promotes an artifact, image tag, or contract name produced by an earlier job and you want the contract to reject drift between them.
+
 You can validate that pattern locally with:
 
 ```bash

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,6 +6,8 @@ variable "RUNTIME_IMAGE_TAG" {
   default = "github-actionspec-rs:local"
 }
 
+variable "CUE_VERSION" {}
+
 target "dev" {
   # Keep a single dev target for every local and CI verification flow so the image
   # contract lives here instead of being duplicated across just recipes and workflows.
@@ -19,6 +21,9 @@ target "runtime" {
   context = "."
   dockerfile = "Dockerfile"
   target = "runtime"
+  args = {
+    CUE_VERSION = CUE_VERSION
+  }
   tags = [RUNTIME_IMAGE_TAG]
 }
 

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ runtime-image := env_var_or_default("GITHUB_ACTIONSPEC_RUNTIME_IMAGE", "github-a
 docker-runner := "./scripts/docker/run.sh"
 docker-runtime-runner := "./scripts/docker/run-runtime.sh"
 host-runner := "mise exec --"
+cue-go-version := `printf 'v%s' "$(mise current asdf:asdf-community/asdf-cue)"`
 
 default:
   @just --list
@@ -16,7 +17,7 @@ docker-build:
   IMAGE_TAG={{docker-image}} docker buildx bake --load dev
 
 docker-build-runtime:
-  RUNTIME_IMAGE_TAG={{runtime-image}} docker buildx bake --load runtime
+  CUE_VERSION={{cue-go-version}} RUNTIME_IMAGE_TAG={{runtime-image}} docker buildx bake --load runtime
 
 docker-smoke-runtime:
   {{docker-runtime-runner}} --help
@@ -26,7 +27,7 @@ docker-run-runtime:
   just docker-smoke-runtime
 
 docker-push-runtime image="docker.io/valproik/github-actionspec-rs:latest":
-  RUNTIME_IMAGE_TAG={{image}} docker buildx bake --push runtime
+  CUE_VERSION={{cue-go-version}} RUNTIME_IMAGE_TAG={{image}} docker buildx bake --push runtime
 
 runtime-ci:
   just docker-build-runtime

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@ fn normalize_actual_inputs(actuals: Vec<PathBuf>) -> Vec<PathBuf> {
     actuals
         .into_iter()
         .flat_map(|actual| {
+            // The GitHub Action accepts newline-delimited payload inputs, so normalize them before
+            // handing control to the validation layer.
             let actual = actual.to_string_lossy();
             actual
                 .lines()
@@ -109,7 +111,7 @@ mod tests {
     #[test]
     fn normalize_actual_inputs_splits_newline_separated_values() {
         let actuals = normalize_actual_inputs(vec![PathBuf::from(
-            "fixtures/one.json\nfixtures/two.json\n",
+            "fixtures/one.json\n\n fixtures/two.json \n",
         )]);
 
         assert_eq!(

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -38,6 +38,12 @@ pub struct ValidateRepoWorkflowResult {
     pub failed_count: usize,
 }
 
+#[derive(Debug, Clone)]
+struct LoadedActual {
+    actual_path: PathBuf,
+    envelope: WorkflowRunEnvelope,
+}
+
 fn assert_readable(path: &Path) -> Result<(), AppError> {
     if !path.is_file() {
         return Err(AppError::MissingReadableFile(path.to_path_buf()));
@@ -89,7 +95,9 @@ fn resolve_actual_paths(paths: &[PathBuf]) -> Result<Vec<PathBuf>, AppError> {
         return Err(AppError::MissingActualPaths);
     }
 
-    let mut resolved_paths = Vec::new();
+    // Resolve every supported input form into a deterministic, de-duplicated file list so
+    // repeated explicit paths or overlapping globs do not trigger duplicate validations.
+    let mut resolved_paths = BTreeSet::new();
     for path in paths {
         if path.is_dir() {
             resolved_paths.extend(collect_directory_actuals(path)?);
@@ -102,23 +110,21 @@ fn resolve_actual_paths(paths: &[PathBuf]) -> Result<Vec<PathBuf>, AppError> {
         }
 
         assert_readable(path)?;
-        resolved_paths.push(path.to_path_buf());
+        resolved_paths.insert(path.to_path_buf());
     }
 
     if resolved_paths.is_empty() {
         return Err(AppError::MissingActualPaths);
     }
 
-    Ok(resolved_paths)
+    Ok(resolved_paths.into_iter().collect())
 }
 
-fn infer_workflow_from_actuals(paths: &[PathBuf]) -> Result<String, AppError> {
+fn infer_workflow_from_actuals(actuals: &[LoadedActual]) -> Result<String, AppError> {
     let mut workflows = BTreeSet::new();
 
-    for path in paths {
-        let contents = fs::read_to_string(path)?;
-        let envelope: WorkflowRunEnvelope = serde_json::from_str(&contents)?;
-        workflows.insert(envelope.run.workflow);
+    for actual in actuals {
+        workflows.insert(actual.envelope.run.workflow.clone());
     }
 
     if workflows.len() == 1 {
@@ -136,6 +142,21 @@ fn infer_workflow_from_actuals(paths: &[PathBuf]) -> Result<String, AppError> {
 fn read_workflow_run(path: &Path) -> Result<WorkflowRunEnvelope, AppError> {
     let contents = fs::read_to_string(path)?;
     Ok(serde_json::from_str(&contents)?)
+}
+
+fn load_actuals(paths: &[PathBuf]) -> Result<Vec<LoadedActual>, AppError> {
+    resolve_actual_paths(paths)?
+        .into_iter()
+        .map(|actual_path| {
+            // Parse each payload once so workflow inference and reporting cannot diverge because
+            // the file changed between repeated reads inside the same validation run.
+            let envelope = read_workflow_run(&actual_path)?;
+            Ok(LoadedActual {
+                actual_path,
+                envelope,
+            })
+        })
+        .collect()
 }
 
 fn apply_env(command: &mut Command, env: &Option<HashMap<String, String>>) {
@@ -254,21 +275,30 @@ pub fn validate_repo_workflow(
         env,
     } = options;
 
-    let actual_paths = resolve_actual_paths(&actual_paths)?;
+    let mut loaded_actuals = None;
     let workflow = match workflow {
         Some(workflow) if !workflow.trim().is_empty() => workflow,
-        _ => infer_workflow_from_actuals(&actual_paths)?,
+        _ => {
+            let actuals = load_actuals(&actual_paths)?;
+            let inferred_workflow = infer_workflow_from_actuals(&actuals)?;
+            loaded_actuals = Some(actuals);
+            inferred_workflow
+        }
     };
 
     let declaration = find_declaration(&repo_root, &workflow, Some(&declarations_dir))?;
     assert_cue_available(&env)?;
+    let actuals = match loaded_actuals {
+        Some(actuals) => actuals,
+        None => load_actuals(&actual_paths)?,
+    };
 
     let mut actual_reports = Vec::new();
     let mut failed = 0;
 
-    for actual_path in actual_paths {
-        let envelope = read_workflow_run(&actual_path)?;
-        let outputs = envelope
+    for actual in actuals {
+        let outputs = actual
+            .envelope
             .run
             .jobs
             .iter()
@@ -279,21 +309,23 @@ pub fn validate_repo_workflow(
                     .map(|outputs| (job_name.clone(), outputs.clone()))
             })
             .collect::<std::collections::BTreeMap<_, _>>();
-        let matrix = envelope
+        let matrix = actual
+            .envelope
             .run
             .jobs
             .values()
             .find_map(|job| job.matrix.clone());
-        let jobs = envelope
+        let jobs = actual
+            .envelope
             .run
             .jobs
-            .into_iter()
-            .map(|(job_name, job)| (job_name, job.result))
+            .iter()
+            .map(|(job_name, job)| (job_name.clone(), job.result.clone()))
             .collect();
         let cue_result = run_cue_vet(
             &[workflow_schema_path(), declaration_schema_path()],
             &declaration.declaration_path,
-            &actual_path,
+            &actual.actual_path,
             cwd.as_deref(),
             &env,
         );
@@ -306,9 +338,9 @@ pub fn validate_repo_workflow(
         };
 
         actual_reports.push(ActualValidationReport {
-            actual_path,
-            workflow: envelope.run.workflow,
-            ref_name: envelope.run.ref_name,
+            actual_path: actual.actual_path,
+            workflow: actual.envelope.run.workflow,
+            ref_name: actual.envelope.run.ref_name,
             status,
             jobs,
             matrix,
@@ -500,6 +532,50 @@ mod tests {
     }
 
     #[test]
+    fn validate_contract_deduplicates_duplicate_actual_paths() {
+        let temp = tempdir().expect("temp dir should be created");
+        let schema = temp.path().join("schema.cue");
+        let contract = temp.path().join("contract.cue");
+        let actual = temp.path().join("actual.json");
+        let calls = temp.path().join("cue-calls.log");
+        fs::write(
+            &schema,
+            "package actionspec\n#WorkflowRun: {workflow: string, jobs: [string]: {result: string}}\n",
+        )
+        .expect("schema should be written");
+        fs::write(
+            &contract,
+            "package actionspec\nrun: #WorkflowRun & {workflow: \"demo\", jobs: {build: {result: \"success\"}}}\n",
+        )
+        .expect("contract should be written");
+        fs::write(
+            &actual,
+            "{\"run\":{\"workflow\":\"demo\",\"jobs\":{\"build\":{\"result\":\"success\"}}}}",
+        )
+        .expect("actual should be written");
+
+        let env = install_fake_cue(
+            temp.path(),
+            &format!(
+                "#!/bin/sh\nif [ \"$1\" = \"version\" ]; then\n  exit 0\nfi\nif [ \"$1\" = \"vet\" ]; then\n  last=\"\"\n  for arg in \"$@\"; do\n    last=\"$arg\"\n  done\n  printf '%s\\n' \"$last\" >> \"{}\"\n  exit 0\nfi\nexit 1\n",
+                calls.display()
+            ),
+        );
+
+        let result = validate_contract(ValidateContractOptions {
+            schema_paths: vec![schema],
+            contract_path: contract,
+            actual_paths: vec![actual.clone(), actual],
+            cwd: Some(temp.path().to_path_buf()),
+            env: Some(env),
+        });
+
+        assert!(result.is_ok());
+        let call_log = fs::read_to_string(calls).expect("call log should exist");
+        assert_eq!(call_log.lines().count(), 1);
+    }
+
+    #[test]
     fn validate_repo_workflow_infers_workflow_from_single_actual() {
         let temp = tempdir().expect("temp dir should be created");
         let declaration_dir = temp.path().join(".github/actionspec/ci");
@@ -526,6 +602,44 @@ mod tests {
             repo_root: temp.path().to_path_buf(),
             workflow: None,
             actual_paths: vec![actual],
+            declarations_dir: PathBuf::from(".github/actionspec"),
+            report_file: None,
+            cwd: None,
+            env: Some(env),
+        })
+        .expect("validation should succeed");
+
+        assert_eq!(result.failed_count, 0);
+        assert_eq!(result.report.actuals.len(), 1);
+    }
+
+    #[test]
+    fn validate_repo_workflow_deduplicates_duplicate_actual_inputs() {
+        let temp = tempdir().expect("temp dir should be created");
+        let declaration_dir = temp.path().join(".github/actionspec/ci");
+        fs::create_dir_all(&declaration_dir).expect("declaration dir should be created");
+        fs::write(
+            declaration_dir.join("main.cue"),
+            "package actionspec\n\nworkflow: \"ci.yml\"\n\nrun: #Declaration.run & {\n  workflow: workflow\n  jobs: {\n    sample: {\n      result: \"success\"\n    }\n  }\n}\n",
+        )
+        .expect("declaration should be written");
+
+        let actual = temp.path().join("actual.json");
+        fs::write(
+            &actual,
+            "{\"run\":{\"workflow\":\"ci.yml\",\"jobs\":{\"sample\":{\"result\":\"success\"}}}}",
+        )
+        .expect("actual should be written");
+
+        let env = install_fake_cue(
+            temp.path(),
+            "#!/bin/sh\nif [ \"$1\" = \"version\" ]; then\n  exit 0\nfi\nif [ \"$1\" = \"vet\" ]; then\n  exit 0\nfi\nexit 1\n",
+        );
+
+        let result = validate_repo_workflow(ValidateRepoWorkflowOptions {
+            repo_root: temp.path().to_path_buf(),
+            workflow: None,
+            actual_paths: vec![actual.clone(), actual],
             declarations_dir: PathBuf::from(".github/actionspec"),
             report_file: None,
             cwd: None,

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -1,8 +1,75 @@
 mod support;
 
+use std::path::{Path, PathBuf};
+
 use assert_cmd::Command;
 use github_actionspec_rs::validate::{validate_contract, ValidateContractOptions};
 use tempfile::tempdir;
+
+fn write_cross_job_fixture(
+    temp_root: &Path,
+    build_tag: &str,
+    published_tag: &str,
+) -> (PathBuf, PathBuf, PathBuf) {
+    let schema = temp_root.join("schema.cue");
+    let contract = temp_root.join("contract.cue");
+    let actual = temp_root.join("actual.json");
+
+    std::fs::write(
+        &schema,
+        "package actionspec\n#WorkflowRun: {\n  workflow: string\n  jobs: [string]: {\n    result: string\n    outputs?: [string]: string\n  }\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &contract,
+        r#"package actionspec
+run: #WorkflowRun & {
+  workflow: "release.yml"
+  jobs: {
+    build: {
+      result: "success"
+      outputs: {
+        image_tag: string
+      }
+    }
+    publish: {
+      result: "success"
+      outputs: {
+        published_tag: run.jobs.build.outputs.image_tag
+      }
+    }
+  }
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        &actual,
+        serde_json::to_string(&serde_json::json!({
+            "run": {
+                "workflow": "release.yml",
+                "jobs": {
+                    "build": {
+                        "result": "success",
+                        "outputs": {
+                            "image_tag": build_tag,
+                        },
+                    },
+                    "publish": {
+                        "result": "success",
+                        "outputs": {
+                            "published_tag": published_tag,
+                        },
+                    },
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    (schema, contract, actual)
+}
 
 #[test]
 fn validates_when_cue_vet_succeeds() {
@@ -204,4 +271,94 @@ exit 1
     assert!(error
         .to_string()
         .contains("matrix app build-ts-service must match outputs.contract_build contract-build",));
+}
+
+#[test]
+fn validates_cross_job_output_invariants() {
+    let temp = tempdir().unwrap();
+    let (schema, contract, actual) = write_cross_job_fixture(
+        temp.path(),
+        "ghcr.io/acme/app:sha-123",
+        "ghcr.io/acme/app:sha-123",
+    );
+
+    let env = support::install_fake_cue_script(
+        temp.path(),
+        r#"#!/bin/sh
+set -eu
+if [ "$1" = "version" ]; then
+  exit 0
+fi
+if [ "$1" = "vet" ]; then
+  last=""
+  for arg in "$@"; do
+    last="$arg"
+  done
+
+  build_tag="$(grep -o '"image_tag":"[^"]*"' "$last" | head -n1 | cut -d'"' -f4)"
+  published_tag="$(grep -o '"published_tag":"[^"]*"' "$last" | head -n1 | cut -d'"' -f4)"
+  [ "${build_tag}" = "${published_tag}" ]
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    let result = validate_contract(ValidateContractOptions {
+        schema_paths: vec![schema],
+        contract_path: contract,
+        actual_paths: vec![actual],
+        cwd: Some(temp.path().to_path_buf()),
+        env: Some(env),
+    });
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn fails_when_cross_job_outputs_diverge() {
+    let temp = tempdir().unwrap();
+    let (schema, contract, actual) = write_cross_job_fixture(
+        temp.path(),
+        "ghcr.io/acme/app:sha-123",
+        "ghcr.io/acme/app:sha-456",
+    );
+
+    let env = support::install_fake_cue_script(
+        temp.path(),
+        r#"#!/bin/sh
+set -eu
+if [ "$1" = "version" ]; then
+  exit 0
+fi
+if [ "$1" = "vet" ]; then
+  last=""
+  for arg in "$@"; do
+    last="$arg"
+  done
+
+  build_tag="$(grep -o '"image_tag":"[^"]*"' "$last" | head -n1 | cut -d'"' -f4)"
+  published_tag="$(grep -o '"published_tag":"[^"]*"' "$last" | head -n1 | cut -d'"' -f4)"
+  if [ "${build_tag}" != "${published_tag}" ]; then
+    echo "publish job must reuse build image tag: ${build_tag} != ${published_tag}" >&2
+    exit 9
+  fi
+  exit 0
+fi
+exit 1
+"#,
+    );
+
+    let error = validate_contract(ValidateContractOptions {
+        schema_paths: vec![schema],
+        contract_path: contract,
+        actual_paths: vec![actual],
+        cwd: Some(temp.path().to_path_buf()),
+        env: Some(env),
+    })
+    .unwrap_err();
+
+    assert!(error
+        .to_string()
+        .contains("publish job must reuse build image tag: ghcr.io/acme/app:sha-123 != ghcr.io/acme/app:sha-456"));
 }


### PR DESCRIPTION
## Summary
- add cross-job invariant tests that tie one job output to another job output
- document the contract pattern where a publish job must reuse the build job artifact tag
- keep the example focused on repository workflows engineers can copy directly

## Verification
- just lint
- just build
- just test