### PR TITLE
#44 Add AI-friendly integration examples to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,118 @@ If you want the smallest GitHub Action integration, start from the generated sni
     dashboard-file: /github/runner_temp/actionspec/current/dashboard.md
 ```
 
+## For AI Tools
+
+If you want an AI agent to integrate the library into another repository, keep the request concrete:
+
+1. Tell it which workflow to validate.
+2. Tell it whether to start from fixture payloads or from runtime capture.
+3. Tell it to keep contracts under `.github/actionspec/<workflow-name>/`.
+4. Tell it to use `just` commands locally and `uses: v4lproik/github-actionspec-rs@main` in workflows.
+
+Repository shape an AI agent should create:
+
+```text
+.github/workflows/ci.yml
+.github/actionspec/ci/main.cue
+tests/fixtures/ci/baseline.json
+target/actionspec/validation-report.json
+target/actionspec/dashboard.md
+```
+
+Minimal local setup:
+
+```bash
+just bootstrap-actionspec . ci.yml
+
+just validate-repo-dashboard . ci.yml \
+  tests/fixtures/ci/baseline.json \
+  target/actionspec/validation-report.json \
+  target/actionspec/dashboard.md
+```
+
+Reusable workflow linting:
+
+```bash
+just validate-callers .
+
+just validate-callers-report . \
+  target/actionspec/callers-report.json
+```
+
+Minimal validation action:
+
+```yaml
+- uses: actions/checkout@v6
+
+- name: Validate ci.yml contract
+  id: actionspec
+  uses: v4lproik/github-actionspec-rs@main
+  with:
+    repo: .
+    workflow: ci.yml
+    actual: tests/fixtures/ci/baseline.json
+    report-file: /github/runner_temp/actionspec/current/validation-report.json
+    dashboard-file: /github/runner_temp/actionspec/current/dashboard.md
+
+- name: Upload actionspec artifacts
+  if: ${{ always() }}
+  uses: actions/upload-artifact@v4
+  with:
+    name: actionspec-ci
+    path: |
+      ${{ steps.actionspec.outputs.report-path }}
+      ${{ steps.actionspec.outputs.dashboard-path }}
+```
+
+Full action flow when the workflow already emits job-level data:
+
+```yaml
+- name: Emit build fragment
+  id: actionspec-build
+  uses: v4lproik/github-actionspec-rs@main
+  with:
+    mode: emit-fragment
+    emit-job: build
+    emit-result: success
+    emit-outputs: |
+      contract_build=build-ts-service
+    emit-matrix: |
+      app=build-ts-service
+    emit-file: /github/runner_temp/actionspec/fragments/build.json
+
+- name: Capture workflow payload
+  id: actionspec-capture
+  uses: v4lproik/github-actionspec-rs@main
+  with:
+    mode: capture
+    workflow: ci.yml
+    ref-name: main
+    capture-job-files: |
+      ${{ steps.actionspec-build.outputs.fragment-path }}
+    capture-file: /github/runner_temp/actionspec/current/workflow-run.json
+
+- name: Validate captured payload
+  id: actionspec-validate
+  uses: v4lproik/github-actionspec-rs@main
+  with:
+    repo: .
+    workflow: ci.yml
+    actual: ${{ steps.actionspec-capture.outputs.capture-path }}
+    report-file: /github/runner_temp/actionspec/current/validation-report.json
+    dashboard-file: /github/runner_temp/actionspec/current/dashboard.md
+    comment-pr: true
+    github-token: ${{ github.token }}
+```
+
+Good instructions for an AI agent:
+
+- Create or tighten `.github/actionspec/<workflow>/main.cue`.
+- Start from one fixture payload before enforcing runtime capture.
+- Add artifact upload for the JSON report and markdown dashboard.
+- Add `just validate-callers .` or `just lint` to CI when reusable workflows are used.
+- Keep the workflow contract next to the workflow it describes.
+
 ## What You Get
 
 - A JSON validation report with workflow metadata, job results, matrix labels, outputs, and typed issues.
@@ -111,6 +223,7 @@ The dashboard starts with a short issue summary so reviewers can see what kind o
 
 - [Overview](https://v4lproik.github.io/github-actionspec-rs/)
 - [Getting Started](https://v4lproik.github.io/github-actionspec-rs/getting-started.html)
+- [Examples](https://v4lproik.github.io/github-actionspec-rs/examples.html)
 - [Workflow Flow](https://v4lproik.github.io/github-actionspec-rs/workflow-flow.html)
 - [Reports](https://v4lproik.github.io/github-actionspec-rs/reports.html)
 - [Troubleshooting](https://v4lproik.github.io/github-actionspec-rs/troubleshooting.html)

--- a/docs/ci-reference.html
+++ b/docs/ci-reference.html
@@ -30,6 +30,7 @@
             <nav class="site-nav" aria-label="Primary">
               <a href="index.html">Overview</a>
               <a href="getting-started.html">Getting Started</a>
+              <a href="examples.html">Examples</a>
               <a href="workflow-flow.html">Workflow Flow</a>
               <a href="reports.html">Reports</a>
               <a href="troubleshooting.html">Troubleshooting</a>

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Examples | github-actionspec-rs</title>
+    <meta
+      name="description"
+      content="Copy-paste examples for integrating github-actionspec-rs locally, in CI, and with AI-assisted tooling."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Public+Sans:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="site-frame">
+      <section class="hero-shell hero-shell-compact">
+        <div class="page-shell">
+          <header class="site-header">
+            <a class="brand" href="index.html" aria-label="github-actionspec-rs home">
+              <span class="brand-mark">
+                <img class="brand-logo" src="logo-mark.svg" alt="" />
+              </span>
+              <span class="brand-text">github-actionspec-rs</span>
+            </a>
+            <nav class="site-nav" aria-label="Primary">
+              <a href="index.html">Overview</a>
+              <a href="getting-started.html">Getting Started</a>
+              <a class="site-nav-active" href="examples.html">Examples</a>
+              <a href="workflow-flow.html">Workflow Flow</a>
+              <a href="reports.html">Reports</a>
+              <a href="troubleshooting.html">Troubleshooting</a>
+              <a href="ci-reference.html">CI</a>
+              <a href="https://github.com/v4lproik/github-actionspec-rs">GitHub</a>
+            </nav>
+          </header>
+
+          <main class="page-intro">
+            <p class="eyebrow">Examples</p>
+            <h1>Copy-paste integration patterns.</h1>
+            <p class="hero-text">
+              These examples are written to be easy for engineers and AI agents to apply. Start
+              with one workflow, one contract, and one payload.
+            </p>
+          </main>
+        </div>
+      </section>
+
+      <div class="page-shell page-shell-body page-shell-tight">
+        <section class="content-section first-section">
+          <div class="doc-grid">
+            <article class="card card-featured">
+              <p class="card-kicker">Repository shape</p>
+              <pre><code>.github/workflows/ci.yml
+.github/actionspec/ci/main.cue
+tests/fixtures/ci/baseline.json
+target/actionspec/validation-report.json
+target/actionspec/dashboard.md</code></pre>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Good defaults</p>
+              <ul class="doc-list">
+                <li>Use one declaration directory per workflow.</li>
+                <li>Start from a baseline fixture before runtime capture.</li>
+                <li>Keep reports and dashboards as uploaded artifacts.</li>
+                <li>Use <code>just</code> locally and the GitHub Action in workflows.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="content-section">
+          <div class="section-heading">
+            <p class="eyebrow">Local bootstrap</p>
+            <h2>Create the first contract and payload.</h2>
+            <p>
+              This is the shortest path for an AI tool: bootstrap from the workflow file, then
+              validate the generated baseline.
+            </p>
+          </div>
+
+          <div class="doc-grid">
+            <article class="code-card">
+              <p class="code-title">Bootstrap</p>
+              <pre><code>just bootstrap-actionspec . ci.yml</code></pre>
+            </article>
+
+            <article class="code-card code-card-dark">
+              <p class="code-title">Validate baseline</p>
+              <pre><code>just validate-repo-dashboard . ci.yml \
+  tests/fixtures/ci/baseline.json \
+  target/actionspec/validation-report.json \
+  target/actionspec/dashboard.md</code></pre>
+            </article>
+          </div>
+        </section>
+
+        <section class="content-section">
+          <div class="section-heading">
+            <p class="eyebrow">Reusable workflows</p>
+            <h2>Lint callers separately.</h2>
+            <p>
+              If the repository uses <code>workflow_call</code>, run interface validation before
+              payload validation.
+            </p>
+          </div>
+
+          <div class="doc-grid">
+            <article class="code-card">
+              <p class="code-title">Quick check</p>
+              <pre><code>just validate-callers .</code></pre>
+            </article>
+
+            <article class="code-card">
+              <p class="code-title">Report for CI artifacts</p>
+              <pre><code>just validate-callers-report . \
+  target/actionspec/callers-report.json</code></pre>
+            </article>
+          </div>
+        </section>
+
+        <section class="content-section">
+          <div class="section-heading">
+            <p class="eyebrow">Minimal action</p>
+            <h2>Validate a fixture payload in GitHub Actions.</h2>
+          </div>
+
+          <article class="code-card">
+            <p class="code-title">Validation-only workflow snippet</p>
+            <pre><code>- uses: actions/checkout@v6
+
+- name: Validate ci.yml contract
+  id: actionspec
+  uses: v4lproik/github-actionspec-rs@main
+  with:
+    repo: .
+    workflow: ci.yml
+    actual: tests/fixtures/ci/baseline.json
+    report-file: /github/runner_temp/actionspec/current/validation-report.json
+    dashboard-file: /github/runner_temp/actionspec/current/dashboard.md
+
+- name: Upload actionspec artifacts
+  if: ${{ always() }}
+  uses: actions/upload-artifact@v4
+  with:
+    name: actionspec-ci
+    path: |
+      ${{ steps.actionspec.outputs.report-path }}
+      ${{ steps.actionspec.outputs.dashboard-path }}</code></pre>
+          </article>
+        </section>
+
+        <section class="content-section">
+          <div class="section-heading">
+            <p class="eyebrow">Full flow</p>
+            <h2>Emit, capture, then validate.</h2>
+            <p>
+              Use this once the workflow already exposes meaningful job status, matrix, or output
+              values.
+            </p>
+          </div>
+
+          <div class="doc-grid">
+            <article class="code-card">
+              <p class="code-title">Emit and capture</p>
+              <pre><code>- name: Emit build fragment
+  id: actionspec-build
+  uses: v4lproik/github-actionspec-rs@main
+  with:
+    mode: emit-fragment
+    emit-job: build
+    emit-result: success
+    emit-outputs: |
+      contract_build=build-ts-service
+    emit-matrix: |
+      app=build-ts-service
+    emit-file: /github/runner_temp/actionspec/fragments/build.json
+
+- name: Capture workflow payload
+  id: actionspec-capture
+  uses: v4lproik/github-actionspec-rs@main
+  with:
+    mode: capture
+    workflow: ci.yml
+    ref-name: main
+    capture-job-files: |
+      ${{ steps.actionspec-build.outputs.fragment-path }}
+    capture-file: /github/runner_temp/actionspec/current/workflow-run.json</code></pre>
+            </article>
+
+            <article class="code-card code-card-dark">
+              <p class="code-title">Validate and publish</p>
+              <pre><code>- name: Validate captured payload
+  id: actionspec-validate
+  uses: v4lproik/github-actionspec-rs@main
+  with:
+    repo: .
+    workflow: ci.yml
+    actual: ${{ steps.actionspec-capture.outputs.capture-path }}
+    report-file: /github/runner_temp/actionspec/current/validation-report.json
+    dashboard-file: /github/runner_temp/actionspec/current/dashboard.md
+    comment-pr: true
+    github-token: ${{ github.token }}
+
+- name: Upload actionspec artifacts
+  if: ${{ always() }}
+  uses: actions/upload-artifact@v4
+  with:
+    name: actionspec-runtime
+    path: |
+      ${{ steps.actionspec-capture.outputs.capture-path }}
+      ${{ steps.actionspec-validate.outputs.report-path }}
+      ${{ steps.actionspec-validate.outputs.dashboard-path }}</code></pre>
+            </article>
+          </div>
+        </section>
+
+        <section class="content-section">
+          <div class="section-heading">
+            <p class="eyebrow">Prompting</p>
+            <h2>Give AI agents explicit tasks.</h2>
+          </div>
+
+          <article class="card">
+            <ul class="doc-list">
+              <li>Create `.github/actionspec/&lt;workflow-name&gt;/main.cue` for one workflow.</li>
+              <li>Generate `tests/fixtures/&lt;workflow-name&gt;/baseline.json` from the current workflow.</li>
+              <li>Add `just validate-callers .` if reusable workflows are used.</li>
+              <li>Add one GitHub Action step that uploads the JSON report and markdown dashboard.</li>
+              <li>Do not start with every workflow. Start with one stable workflow and expand later.</li>
+            </ul>
+          </article>
+        </section>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -30,6 +30,7 @@
             <nav class="site-nav" aria-label="Primary">
               <a href="index.html">Overview</a>
               <a class="site-nav-active" href="getting-started.html">Getting Started</a>
+              <a href="examples.html">Examples</a>
               <a href="workflow-flow.html">Workflow Flow</a>
               <a href="reports.html">Reports</a>
               <a href="troubleshooting.html">Troubleshooting</a>
@@ -178,6 +179,7 @@ just validate-callers-report . \
               <ul class="doc-list doc-list-inverse">
                 <li>Start with the generated baseline payload.</li>
                 <li>Switch to captured payloads when the workflow already emits useful fragments.</li>
+                <li>Use the examples page when you want copy-paste snippets for AI-assisted setup.</li>
                 <li>Add matrix dashboards when reviewers need diffs.</li>
                 <li>Add runtime-backed capture once the workflow is stable enough to enforce on protected branches.</li>
                 <li>Use the troubleshooting page when the first validation failures are not obvious.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,6 +37,7 @@
             <nav class="site-nav" aria-label="Primary">
               <a class="site-nav-active" href="index.html">Overview</a>
               <a href="getting-started.html">Getting Started</a>
+              <a href="examples.html">Examples</a>
               <a href="workflow-flow.html">Workflow Flow</a>
               <a href="reports.html">Reports</a>
               <a href="troubleshooting.html">Troubleshooting</a>
@@ -59,6 +60,7 @@
               </p>
               <div class="hero-actions">
                 <a class="button button-primary" href="#how">See the flow</a>
+                <a class="button button-secondary" href="examples.html">Examples</a>
                 <a
                   class="button button-secondary"
                   href="https://github.com/v4lproik/github-actionspec-rs#readme"
@@ -220,6 +222,11 @@ run: #Declaration.run & {
               <p class="card-kicker">GitHub Action</p>
               <h3>Workflow integration</h3>
               <p>Run emit, capture, and validate flows inside GitHub Actions with the bundled runtime.</p>
+            </article>
+            <article class="card docs-card">
+              <p class="card-kicker">Examples</p>
+              <h3>AI-friendly patterns</h3>
+              <p>Use the examples page when you want copy-paste snippets for local setup or CI integration.</p>
             </article>
             <article class="card docs-card">
               <p class="card-kicker">Runtime image</p>

--- a/docs/reports.html
+++ b/docs/reports.html
@@ -30,6 +30,7 @@
             <nav class="site-nav" aria-label="Primary">
               <a href="index.html">Overview</a>
               <a href="getting-started.html">Getting Started</a>
+              <a href="examples.html">Examples</a>
               <a href="workflow-flow.html">Workflow Flow</a>
               <a class="site-nav-active" href="reports.html">Reports</a>
               <a href="troubleshooting.html">Troubleshooting</a>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -30,6 +30,7 @@
             <nav class="site-nav" aria-label="Primary">
               <a href="index.html">Overview</a>
               <a href="getting-started.html">Getting Started</a>
+              <a href="examples.html">Examples</a>
               <a href="workflow-flow.html">Workflow Flow</a>
               <a href="reports.html">Reports</a>
               <a class="site-nav-active" href="troubleshooting.html">Troubleshooting</a>

--- a/docs/workflow-flow.html
+++ b/docs/workflow-flow.html
@@ -30,6 +30,7 @@
             <nav class="site-nav" aria-label="Primary">
               <a href="index.html">Overview</a>
               <a href="getting-started.html">Getting Started</a>
+              <a href="examples.html">Examples</a>
               <a class="site-nav-active" href="workflow-flow.html">Workflow Flow</a>
               <a href="reports.html">Reports</a>
               <a href="troubleshooting.html">Troubleshooting</a>


### PR DESCRIPTION
## Summary
- add a dedicated examples page with copy-paste local and CI integration patterns
- expand the README with an AI-oriented setup section and workflow snippets
- link the new examples page from the existing docs navigation

## Verification
- git diff --check